### PR TITLE
remove @Nullable and @Nonull annotations

### DIFF
--- a/.github/workflows/publish-to-maven-central.yaml
+++ b/.github/workflows/publish-to-maven-central.yaml
@@ -61,4 +61,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag $VERSION
-          git push origin $VERSION        
+          git push origin $VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,13 @@ plugins {
 }
 
 group = 'de.codebarista'
-version = '0.0.2'
+version = '0.0.3'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 repositories {
     mavenCentral()
@@ -89,7 +95,11 @@ mavenPublishing {
     }
 
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    signAllPublications()
+
+    // Only sign if publishing to Maven Central (not for local)
+    if (project.hasProperty("signing.keyId")) {
+        signAllPublications()
+    }
 }
 
 tasks.register('printVersion') {

--- a/src/main/java/de/codebarista/shopware/model/core/AccountNewsletterRecipientResult.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AccountNewsletterRecipientResult.java
@@ -47,7 +47,6 @@ public class AccountNewsletterRecipientResult {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -73,7 +72,6 @@ public class AccountNewsletterRecipientResult {
    * Get status
    * @return status
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -128,4 +126,3 @@ public class AccountNewsletterRecipientResult {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AclRole.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AclRole.java
@@ -63,7 +63,6 @@ public class AclRole {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class AclRole {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class AclRole {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class AclRole {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/App.java
+++ b/src/main/java/de/codebarista/shopware/model/core/App.java
@@ -67,7 +67,6 @@ public class App {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class App {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class App {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class App {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class App {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppActionButton.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppActionButton.java
@@ -67,7 +67,6 @@ public class AppActionButton {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class AppActionButton {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class AppActionButton {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class AppActionButton {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class AppActionButton {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppAdministrationSnippet.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppAdministrationSnippet.java
@@ -75,7 +75,6 @@ public class AppAdministrationSnippet {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class AppAdministrationSnippet {
    * Get value
    * @return value
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -127,7 +125,6 @@ public class AppAdministrationSnippet {
    * Get appId
    * @return appId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_APP_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -153,7 +150,6 @@ public class AppAdministrationSnippet {
    * Get localeId
    * @return localeId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LOCALE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -173,7 +169,6 @@ public class AppAdministrationSnippet {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -188,7 +183,6 @@ public class AppAdministrationSnippet {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -246,4 +240,3 @@ public class AppAdministrationSnippet {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppCmsBlock.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppCmsBlock.java
@@ -67,7 +67,6 @@ public class AppCmsBlock {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class AppCmsBlock {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class AppCmsBlock {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class AppCmsBlock {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class AppCmsBlock {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppFlowAction.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppFlowAction.java
@@ -67,7 +67,6 @@ public class AppFlowAction {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class AppFlowAction {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class AppFlowAction {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class AppFlowAction {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class AppFlowAction {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppFlowEvent.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppFlowEvent.java
@@ -63,7 +63,6 @@ public class AppFlowEvent {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class AppFlowEvent {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class AppFlowEvent {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class AppFlowEvent {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppPaymentMethod.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppPaymentMethod.java
@@ -63,7 +63,6 @@ public class AppPaymentMethod {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class AppPaymentMethod {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class AppPaymentMethod {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class AppPaymentMethod {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppScriptCondition.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppScriptCondition.java
@@ -67,7 +67,6 @@ public class AppScriptCondition {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class AppScriptCondition {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class AppScriptCondition {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class AppScriptCondition {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class AppScriptCondition {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppShippingMethod.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppShippingMethod.java
@@ -63,7 +63,6 @@ public class AppShippingMethod {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class AppShippingMethod {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class AppShippingMethod {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class AppShippingMethod {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/AppTemplate.java
+++ b/src/main/java/de/codebarista/shopware/model/core/AppTemplate.java
@@ -63,7 +63,6 @@ public class AppTemplate {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class AppTemplate {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class AppTemplate {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class AppTemplate {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CancelOrderRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CancelOrderRequest.java
@@ -45,7 +45,6 @@ public class CancelOrderRequest {
    * The identifier of the order to be canceled.
    * @return orderId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CancelOrderRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Cart.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Cart.java
@@ -85,7 +85,6 @@ public class Cart {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -111,7 +110,6 @@ public class Cart {
    * Name of the cart - for example &#x60;guest-cart&#x60;
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -137,7 +135,6 @@ public class Cart {
    * Context token identifying the cart and the user session
    * @return token
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +160,6 @@ public class Cart {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -197,7 +193,6 @@ public class Cart {
    * All items within the cart
    * @return lineItems
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINE_ITEMS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -231,7 +226,6 @@ public class Cart {
    * A list of all cart errors, such as insufficient stocks, invalid addresses or vouchers.
    * @return errors
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ERRORS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -265,7 +259,6 @@ public class Cart {
    * A list of all payment transactions associated with the current cart.
    * @return transactions
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSACTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -291,7 +284,6 @@ public class Cart {
    * Get modified
    * @return modified
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MODIFIED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -317,7 +309,6 @@ public class Cart {
    * A comment that can be added to the cart.
    * @return customerComment
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_COMMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -343,7 +334,6 @@ public class Cart {
    * An affiliate tracking code
    * @return affiliateCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFFILIATE_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -369,7 +359,6 @@ public class Cart {
    * A campaign tracking code
    * @return campaignCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAMPAIGN_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -442,4 +431,3 @@ public class Cart {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CartAllOfErrors.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CartAllOfErrors.java
@@ -53,7 +53,6 @@ public class CartAllOfErrors {
    * Get key
    * @return key
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -79,7 +78,6 @@ public class CartAllOfErrors {
    * Get level
    * @return level
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LEVEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class CartAllOfErrors {
    * Get message
    * @return message
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MESSAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class CartAllOfErrors {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CartAllOfPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CartAllOfPrice.java
@@ -57,7 +57,6 @@ public class CartAllOfPrice {
    * Net price of the cart
    * @return netPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NET_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CartAllOfPrice {
    * Total price of the cart, including shipping costs, discounts and taxes
    * @return totalPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +107,6 @@ public class CartAllOfPrice {
    * Price for all line items in the cart
    * @return positionPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +132,6 @@ public class CartAllOfPrice {
    * Tax calculation for the cart. One of &#x60;gross&#x60;, &#x60;net&#x60; or &#x60;tax-free&#x60;
    * @return taxStatus
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,4 +190,3 @@ public class CartAllOfPrice {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CartAllOfTransactions.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CartAllOfTransactions.java
@@ -45,7 +45,6 @@ public class CartAllOfTransactions {
    * Get paymentMethodId
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CartAllOfTransactions {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CartItems.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CartItems.java
@@ -49,7 +49,6 @@ public class CartItems {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CartItems {
    * Get items
    * @return items
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ITEMS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -138,4 +136,3 @@ public class CartItems {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Category.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Category.java
@@ -221,7 +221,6 @@ public class Category {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -247,7 +246,6 @@ public class Category {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -273,7 +271,6 @@ public class Category {
    * Get parentId
    * @return parentId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -299,7 +296,6 @@ public class Category {
    * Get parentVersionId
    * @return parentVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -325,7 +321,6 @@ public class Category {
    * Get afterCategoryId
    * @return afterCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFTER_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -351,7 +346,6 @@ public class Category {
    * Get afterCategoryVersionId
    * @return afterCategoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFTER_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -377,7 +371,6 @@ public class Category {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -403,7 +396,6 @@ public class Category {
    * Get displayNestedProducts
    * @return displayNestedProducts
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DISPLAY_NESTED_PRODUCTS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -423,7 +415,6 @@ public class Category {
    * Get breadcrumb
    * @return breadcrumb
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BREADCRUMB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -438,7 +429,6 @@ public class Category {
    * Get level
    * @return level
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LEVEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -453,7 +443,6 @@ public class Category {
    * Get path
    * @return path
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PATH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -468,7 +457,6 @@ public class Category {
    * Get childCount
    * @return childCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -489,7 +477,6 @@ public class Category {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -515,7 +502,6 @@ public class Category {
    * Get productAssignmentType
    * @return productAssignmentType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ASSIGNMENT_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -541,7 +527,6 @@ public class Category {
    * Get visible
    * @return visible
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -567,7 +552,6 @@ public class Category {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -593,7 +577,6 @@ public class Category {
    * Runtime field, cannot be used as part of the criteria.
    * @return cmsPageIdSwitched
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID_SWITCHED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -619,7 +602,6 @@ public class Category {
    * Runtime field, cannot be used as part of the criteria.
    * @return visibleChildCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBLE_CHILD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -645,7 +627,6 @@ public class Category {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -671,7 +652,6 @@ public class Category {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -697,7 +677,6 @@ public class Category {
    * Get linkType
    * @return linkType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINK_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -723,7 +702,6 @@ public class Category {
    * Get internalLink
    * @return internalLink
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_INTERNAL_LINK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -749,7 +727,6 @@ public class Category {
    * Get externalLink
    * @return externalLink
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EXTERNAL_LINK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -775,7 +752,6 @@ public class Category {
    * Get linkNewTab
    * @return linkNewTab
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINK_NEW_TAB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -801,7 +777,6 @@ public class Category {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -827,7 +802,6 @@ public class Category {
    * Get metaTitle
    * @return metaTitle
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -853,7 +827,6 @@ public class Category {
    * Get metaDescription
    * @return metaDescription
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -879,7 +852,6 @@ public class Category {
    * Get keywords
    * @return keywords
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_KEYWORDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -905,7 +877,6 @@ public class Category {
    * Get cmsPageId
    * @return cmsPageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -931,7 +902,6 @@ public class Category {
    * Get cmsPageVersionId
    * @return cmsPageVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -957,7 +927,6 @@ public class Category {
    * Get customEntityTypeId
    * @return customEntityTypeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_ENTITY_TYPE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -977,7 +946,6 @@ public class Category {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -992,7 +960,6 @@ public class Category {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1013,7 +980,6 @@ public class Category {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1039,7 +1005,6 @@ public class Category {
    * Get parent
    * @return parent
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1073,7 +1038,6 @@ public class Category {
    * Get children
    * @return children
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILDREN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1099,7 +1063,6 @@ public class Category {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1133,7 +1096,6 @@ public class Category {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1159,7 +1121,6 @@ public class Category {
    * Get cmsPage
    * @return cmsPage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1193,7 +1154,6 @@ public class Category {
    * Get seoUrls
    * @return seoUrls
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SEO_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1324,4 +1284,3 @@ public class Category {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApi.java
@@ -215,7 +215,6 @@ public class CategoryJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -241,7 +240,6 @@ public class CategoryJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -275,7 +273,6 @@ public class CategoryJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -301,7 +298,6 @@ public class CategoryJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -335,7 +331,6 @@ public class CategoryJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -369,7 +364,6 @@ public class CategoryJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -395,7 +389,6 @@ public class CategoryJsonApi {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -421,7 +414,6 @@ public class CategoryJsonApi {
    * Get parentId
    * @return parentId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -447,7 +439,6 @@ public class CategoryJsonApi {
    * Get parentVersionId
    * @return parentVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -473,7 +464,6 @@ public class CategoryJsonApi {
    * Get afterCategoryId
    * @return afterCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFTER_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -499,7 +489,6 @@ public class CategoryJsonApi {
    * Get afterCategoryVersionId
    * @return afterCategoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFTER_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -525,7 +514,6 @@ public class CategoryJsonApi {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -551,7 +539,6 @@ public class CategoryJsonApi {
    * Get displayNestedProducts
    * @return displayNestedProducts
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DISPLAY_NESTED_PRODUCTS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -571,7 +558,6 @@ public class CategoryJsonApi {
    * Get breadcrumb
    * @return breadcrumb
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BREADCRUMB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -586,7 +572,6 @@ public class CategoryJsonApi {
    * Get level
    * @return level
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LEVEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -601,7 +586,6 @@ public class CategoryJsonApi {
    * Get path
    * @return path
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PATH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -616,7 +600,6 @@ public class CategoryJsonApi {
    * Get childCount
    * @return childCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -637,7 +620,6 @@ public class CategoryJsonApi {
    * Get productAssignmentType
    * @return productAssignmentType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ASSIGNMENT_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -663,7 +645,6 @@ public class CategoryJsonApi {
    * Get visible
    * @return visible
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -689,7 +670,6 @@ public class CategoryJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -715,7 +695,6 @@ public class CategoryJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return cmsPageIdSwitched
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID_SWITCHED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -741,7 +720,6 @@ public class CategoryJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return visibleChildCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBLE_CHILD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -767,7 +745,6 @@ public class CategoryJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -793,7 +770,6 @@ public class CategoryJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -819,7 +795,6 @@ public class CategoryJsonApi {
    * Get linkType
    * @return linkType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINK_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -845,7 +820,6 @@ public class CategoryJsonApi {
    * Get internalLink
    * @return internalLink
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_INTERNAL_LINK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -871,7 +845,6 @@ public class CategoryJsonApi {
    * Get externalLink
    * @return externalLink
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EXTERNAL_LINK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -897,7 +870,6 @@ public class CategoryJsonApi {
    * Get linkNewTab
    * @return linkNewTab
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINK_NEW_TAB)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -923,7 +895,6 @@ public class CategoryJsonApi {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -949,7 +920,6 @@ public class CategoryJsonApi {
    * Get metaTitle
    * @return metaTitle
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -975,7 +945,6 @@ public class CategoryJsonApi {
    * Get metaDescription
    * @return metaDescription
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1001,7 +970,6 @@ public class CategoryJsonApi {
    * Get keywords
    * @return keywords
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_KEYWORDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1027,7 +995,6 @@ public class CategoryJsonApi {
    * Get cmsPageId
    * @return cmsPageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1053,7 +1020,6 @@ public class CategoryJsonApi {
    * Get cmsPageVersionId
    * @return cmsPageVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1079,7 +1045,6 @@ public class CategoryJsonApi {
    * Get customEntityTypeId
    * @return customEntityTypeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_ENTITY_TYPE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1099,7 +1064,6 @@ public class CategoryJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1114,7 +1078,6 @@ public class CategoryJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1135,7 +1098,6 @@ public class CategoryJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1262,4 +1224,3 @@ public class CategoryJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationships.java
@@ -65,7 +65,6 @@ public class CategoryJsonApiAllOfRelationships {
    * Get parent
    * @return parent
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -91,7 +90,6 @@ public class CategoryJsonApiAllOfRelationships {
    * Get children
    * @return children
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILDREN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +115,6 @@ public class CategoryJsonApiAllOfRelationships {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -143,7 +140,6 @@ public class CategoryJsonApiAllOfRelationships {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -169,7 +165,6 @@ public class CategoryJsonApiAllOfRelationships {
    * Get cmsPage
    * @return cmsPage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -195,7 +190,6 @@ public class CategoryJsonApiAllOfRelationships {
    * Get seoUrls
    * @return seoUrls
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SEO_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -258,4 +252,3 @@ public class CategoryJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsChildren.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsChildren.java
@@ -51,7 +51,6 @@ public class CategoryJsonApiAllOfRelationshipsChildren {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class CategoryJsonApiAllOfRelationshipsChildren {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class CategoryJsonApiAllOfRelationshipsChildren {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsChildrenData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsChildrenData.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsChildrenData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsChildrenData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsChildrenData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsChildrenLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsChildrenLinks.java
@@ -45,7 +45,6 @@ public class CategoryJsonApiAllOfRelationshipsChildrenLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CategoryJsonApiAllOfRelationshipsChildrenLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsCmsPage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsCmsPage.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsCmsPage {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsCmsPage {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsCmsPage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsCmsPageData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsCmsPageData.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsCmsPageData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsCmsPageData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsCmsPageData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsCmsPageLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsCmsPageLinks.java
@@ -45,7 +45,6 @@ public class CategoryJsonApiAllOfRelationshipsCmsPageLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CategoryJsonApiAllOfRelationshipsCmsPageLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsMedia.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsMedia {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsMedia {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsMediaData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsMediaData.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsMediaData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsMediaData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsMediaData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsMediaLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsMediaLinks.java
@@ -45,7 +45,6 @@ public class CategoryJsonApiAllOfRelationshipsMediaLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CategoryJsonApiAllOfRelationshipsMediaLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsParent.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsParent.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsParent {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsParent {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsParent {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsParentData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsParentData.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsParentData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsParentData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsParentData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsParentLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsParentLinks.java
@@ -45,7 +45,6 @@ public class CategoryJsonApiAllOfRelationshipsParentLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CategoryJsonApiAllOfRelationshipsParentLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsSeoUrls.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsSeoUrls.java
@@ -51,7 +51,6 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrls {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrls {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrls {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsSeoUrlsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsSeoUrlsData.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrlsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrlsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrlsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsSeoUrlsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsSeoUrlsLinks.java
@@ -45,7 +45,6 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrlsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CategoryJsonApiAllOfRelationshipsSeoUrlsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsTags.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsTags.java
@@ -51,7 +51,6 @@ public class CategoryJsonApiAllOfRelationshipsTags {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class CategoryJsonApiAllOfRelationshipsTags {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class CategoryJsonApiAllOfRelationshipsTags {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsTagsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsTagsData.java
@@ -49,7 +49,6 @@ public class CategoryJsonApiAllOfRelationshipsTagsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CategoryJsonApiAllOfRelationshipsTagsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CategoryJsonApiAllOfRelationshipsTagsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsTagsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CategoryJsonApiAllOfRelationshipsTagsLinks.java
@@ -45,7 +45,6 @@ public class CategoryJsonApiAllOfRelationshipsTagsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CategoryJsonApiAllOfRelationshipsTagsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ChangeEmailRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ChangeEmailRequest.java
@@ -53,7 +53,6 @@ public class ChangeEmailRequest {
    * New email address. Has to be unique amongst all customers
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class ChangeEmailRequest {
    * Confirmation of the new email address.
    * @return emailConfirmation
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL_CONFIRMATION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -105,7 +103,6 @@ public class ChangeEmailRequest {
    * Customer&#39;s current password
    * @return password
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,4 +159,3 @@ public class ChangeEmailRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ChangeLanguageRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ChangeLanguageRequest.java
@@ -45,7 +45,6 @@ public class ChangeLanguageRequest {
    * New languageId
    * @return language
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ChangeLanguageRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ChangePasswordRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ChangePasswordRequest.java
@@ -53,7 +53,6 @@ public class ChangePasswordRequest {
    * Current password of the customer
    * @return password
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class ChangePasswordRequest {
    * New Password for the customer
    * @return newPassword
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NEW_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -105,7 +103,6 @@ public class ChangePasswordRequest {
    * Confirmation of the new password
    * @return newPasswordConfirm
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NEW_PASSWORD_CONFIRM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,4 +159,3 @@ public class ChangePasswordRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ChangeProfileRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ChangeProfileRequest.java
@@ -73,7 +73,6 @@ public class ChangeProfileRequest {
    * Id of the salutation for the customer account. Fetch options using &#x60;salutation&#x60; endpoint.
    * @return salutationId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -99,7 +98,6 @@ public class ChangeProfileRequest {
    * (Academic) title of the customer
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +123,6 @@ public class ChangeProfileRequest {
    * Customer first name. Value will be reused for shipping and billing address if not provided explicitly.
    * @return firstName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -151,7 +148,6 @@ public class ChangeProfileRequest {
    * Customer last name. Value will be reused for shipping and billing address if not provided explicitly.
    * @return lastName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -177,7 +173,6 @@ public class ChangeProfileRequest {
    * Company of the customer. Only required when &#x60;accountType&#x60; is &#x60;business&#x60;.
    * @return company
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class ChangeProfileRequest {
    * Birthday day
    * @return birthdayDay
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY_DAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +223,6 @@ public class ChangeProfileRequest {
    * Birthday month
    * @return birthdayMonth
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY_MONTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +248,6 @@ public class ChangeProfileRequest {
    * Birthday year
    * @return birthdayYear
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY_YEAR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,4 +314,3 @@ public class ChangeProfileRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CmsBlock.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CmsBlock.java
@@ -141,7 +141,6 @@ public class CmsBlock {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -167,7 +166,6 @@ public class CmsBlock {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -193,7 +191,6 @@ public class CmsBlock {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -219,7 +216,6 @@ public class CmsBlock {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -245,7 +241,6 @@ public class CmsBlock {
    * Get sectionPosition
    * @return sectionPosition
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SECTION_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -271,7 +266,6 @@ public class CmsBlock {
    * Get marginTop
    * @return marginTop
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MARGIN_TOP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -297,7 +291,6 @@ public class CmsBlock {
    * Get marginBottom
    * @return marginBottom
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MARGIN_BOTTOM)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -323,7 +316,6 @@ public class CmsBlock {
    * Get marginLeft
    * @return marginLeft
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MARGIN_LEFT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -349,7 +341,6 @@ public class CmsBlock {
    * Get marginRight
    * @return marginRight
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MARGIN_RIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -375,7 +366,6 @@ public class CmsBlock {
    * Get backgroundColor
    * @return backgroundColor
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_COLOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -401,7 +391,6 @@ public class CmsBlock {
    * Get backgroundMediaId
    * @return backgroundMediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -427,7 +416,6 @@ public class CmsBlock {
    * Get backgroundMediaMode
    * @return backgroundMediaMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_MEDIA_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -453,7 +441,6 @@ public class CmsBlock {
    * Get cssClass
    * @return cssClass
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CSS_CLASS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -479,7 +466,6 @@ public class CmsBlock {
    * Get visibility
    * @return visibility
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBILITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -505,7 +491,6 @@ public class CmsBlock {
    * Get sectionId
    * @return sectionId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SECTION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -531,7 +516,6 @@ public class CmsBlock {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -557,7 +541,6 @@ public class CmsBlock {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -583,7 +566,6 @@ public class CmsBlock {
    * Get cmsSectionVersionId
    * @return cmsSectionVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_SECTION_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -603,7 +585,6 @@ public class CmsBlock {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -618,7 +599,6 @@ public class CmsBlock {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -639,7 +619,6 @@ public class CmsBlock {
    * Get backgroundMedia
    * @return backgroundMedia
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -673,7 +652,6 @@ public class CmsBlock {
    * Get slots
    * @return slots
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SLOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -768,4 +746,3 @@ public class CmsBlock {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CmsBlockVisibility.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CmsBlockVisibility.java
@@ -53,7 +53,6 @@ public class CmsBlockVisibility {
    * Get mobile
    * @return mobile
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MOBILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -79,7 +78,6 @@ public class CmsBlockVisibility {
    * Get desktop
    * @return desktop
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESKTOP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class CmsBlockVisibility {
    * Get tablet
    * @return tablet
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TABLET)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class CmsBlockVisibility {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CmsPage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CmsPage.java
@@ -113,7 +113,6 @@ public class CmsPage {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -139,7 +138,6 @@ public class CmsPage {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -165,7 +163,6 @@ public class CmsPage {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -191,7 +188,6 @@ public class CmsPage {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +213,6 @@ public class CmsPage {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +238,6 @@ public class CmsPage {
    * Get cssClass
    * @return cssClass
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CSS_CLASS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -269,7 +263,6 @@ public class CmsPage {
    * Get config
    * @return config
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONFIG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -295,7 +288,6 @@ public class CmsPage {
    * Get previewMediaId
    * @return previewMediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREVIEW_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -321,7 +313,6 @@ public class CmsPage {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +332,6 @@ public class CmsPage {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -356,7 +346,6 @@ public class CmsPage {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -377,7 +366,6 @@ public class CmsPage {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -411,7 +399,6 @@ public class CmsPage {
    * Get sections
    * @return sections
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SECTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -437,7 +424,6 @@ public class CmsPage {
    * Get previewMedia
    * @return previewMedia
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREVIEW_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -471,7 +457,6 @@ public class CmsPage {
    * Get landingPages
    * @return landingPages
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANDING_PAGES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -552,4 +537,3 @@ public class CmsPage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CmsPageConfig.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CmsPageConfig.java
@@ -45,7 +45,6 @@ public class CmsPageConfig {
    * Get backgroundColor
    * @return backgroundColor
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_COLOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CmsPageConfig {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CmsSection.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CmsSection.java
@@ -129,7 +129,6 @@ public class CmsSection {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -155,7 +154,6 @@ public class CmsSection {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -181,7 +179,6 @@ public class CmsSection {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -207,7 +204,6 @@ public class CmsSection {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -233,7 +229,6 @@ public class CmsSection {
    * Get sizingMode
    * @return sizingMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SIZING_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -259,7 +254,6 @@ public class CmsSection {
    * Get mobileBehavior
    * @return mobileBehavior
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MOBILE_BEHAVIOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +279,6 @@ public class CmsSection {
    * Get backgroundColor
    * @return backgroundColor
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_COLOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -311,7 +304,6 @@ public class CmsSection {
    * Get backgroundMediaId
    * @return backgroundMediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +329,6 @@ public class CmsSection {
    * Get backgroundMediaMode
    * @return backgroundMediaMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_MEDIA_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +354,6 @@ public class CmsSection {
    * Get cssClass
    * @return cssClass
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CSS_CLASS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -389,7 +379,6 @@ public class CmsSection {
    * Get pageId
    * @return pageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -415,7 +404,6 @@ public class CmsSection {
    * Get visibility
    * @return visibility
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBILITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -441,7 +429,6 @@ public class CmsSection {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -467,7 +454,6 @@ public class CmsSection {
    * Get cmsPageVersionId
    * @return cmsPageVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -487,7 +473,6 @@ public class CmsSection {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -502,7 +487,6 @@ public class CmsSection {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -523,7 +507,6 @@ public class CmsSection {
    * Get page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -549,7 +532,6 @@ public class CmsSection {
    * Get backgroundMedia
    * @return backgroundMedia
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BACKGROUND_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -583,7 +565,6 @@ public class CmsSection {
    * Get blocks
    * @return blocks
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BLOCKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -672,4 +653,3 @@ public class CmsSection {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CmsSlot.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CmsSlot.java
@@ -113,7 +113,6 @@ public class CmsSlot {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -139,7 +138,6 @@ public class CmsSlot {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -165,7 +163,6 @@ public class CmsSlot {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -191,7 +188,6 @@ public class CmsSlot {
    * Get slot
    * @return slot
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SLOT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +213,6 @@ public class CmsSlot {
    * Get locked
    * @return locked
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LOCKED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +238,6 @@ public class CmsSlot {
    * Get config
    * @return config
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONFIG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -269,7 +263,6 @@ public class CmsSlot {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -289,7 +282,6 @@ public class CmsSlot {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -310,7 +302,6 @@ public class CmsSlot {
    * Get blockId
    * @return blockId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_BLOCK_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -336,7 +327,6 @@ public class CmsSlot {
    * Get fieldConfig
    * @return fieldConfig
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELD_CONFIG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -362,7 +352,6 @@ public class CmsSlot {
    * Get cmsBlockVersionId
    * @return cmsBlockVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_BLOCK_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -382,7 +371,6 @@ public class CmsSlot {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -397,7 +385,6 @@ public class CmsSlot {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -418,7 +405,6 @@ public class CmsSlot {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -444,7 +430,6 @@ public class CmsSlot {
    * Get block
    * @return block
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BLOCK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -525,4 +510,3 @@ public class CmsSlot {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CodebaristaDeliverydateConfigHolidays.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CodebaristaDeliverydateConfigHolidays.java
@@ -63,7 +63,6 @@ public class CodebaristaDeliverydateConfigHolidays {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CodebaristaDeliverydateConfigHolidays {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CodebaristaDeliverydateConfigHolidays {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CodebaristaDeliverydateConfigHolidays {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CodebaristaDeliverydatePluginSettings.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CodebaristaDeliverydatePluginSettings.java
@@ -63,7 +63,6 @@ public class CodebaristaDeliverydatePluginSettings {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CodebaristaDeliverydatePluginSettings {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CodebaristaDeliverydatePluginSettings {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CodebaristaDeliverydatePluginSettings {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CodebaristaShopwareuploadLocaluploadtoken.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CodebaristaShopwareuploadLocaluploadtoken.java
@@ -63,7 +63,6 @@ public class CodebaristaShopwareuploadLocaluploadtoken {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CodebaristaShopwareuploadLocaluploadtoken {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CodebaristaShopwareuploadLocaluploadtoken {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CodebaristaShopwareuploadLocaluploadtoken {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CodebaristaShopwareuploadReupload.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CodebaristaShopwareuploadReupload.java
@@ -63,7 +63,6 @@ public class CodebaristaShopwareuploadReupload {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CodebaristaShopwareuploadReupload {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CodebaristaShopwareuploadReupload {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CodebaristaShopwareuploadReupload {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ConfirmNewsletterRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ConfirmNewsletterRequest.java
@@ -49,7 +49,6 @@ public class ConfirmNewsletterRequest {
    * Hash parameter from link the in the confirmation mail
    * @return hash
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HASH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -75,7 +74,6 @@ public class ConfirmNewsletterRequest {
    * Email hash parameter from the link in the confirmation mail
    * @return em
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,4 +128,3 @@ public class ConfirmNewsletterRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Country.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Country.java
@@ -153,7 +153,6 @@ public class Country {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -179,7 +178,6 @@ public class Country {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -205,7 +203,6 @@ public class Country {
    * Get iso
    * @return iso
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ISO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -231,7 +228,6 @@ public class Country {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -257,7 +253,6 @@ public class Country {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -283,7 +278,6 @@ public class Country {
    * Get shippingAvailable
    * @return shippingAvailable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -309,7 +303,6 @@ public class Country {
    * Get iso3
    * @return iso3
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ISO3)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -335,7 +328,6 @@ public class Country {
    * Get displayStateInRegistration
    * @return displayStateInRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISPLAY_STATE_IN_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -361,7 +353,6 @@ public class Country {
    * Get forceStateInRegistration
    * @return forceStateInRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FORCE_STATE_IN_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -387,7 +378,6 @@ public class Country {
    * Get checkVatIdPattern
    * @return checkVatIdPattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_VAT_ID_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -413,7 +403,6 @@ public class Country {
    * Get vatIdRequired
    * @return vatIdRequired
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_ID_REQUIRED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -439,7 +428,6 @@ public class Country {
    * Get vatIdPattern
    * @return vatIdPattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_ID_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -465,7 +453,6 @@ public class Country {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -491,7 +478,6 @@ public class Country {
    * Get customerTax
    * @return customerTax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -517,7 +503,6 @@ public class Country {
    * Get companyTax
    * @return companyTax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -543,7 +528,6 @@ public class Country {
    * Get postalCodeRequired
    * @return postalCodeRequired
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSTAL_CODE_REQUIRED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -569,7 +553,6 @@ public class Country {
    * Get checkPostalCodePattern
    * @return checkPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -595,7 +578,6 @@ public class Country {
    * Get checkAdvancedPostalCodePattern
    * @return checkAdvancedPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_ADVANCED_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -621,7 +603,6 @@ public class Country {
    * Get advancedPostalCodePattern
    * @return advancedPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADVANCED_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -647,7 +628,6 @@ public class Country {
    * Get addressFormat
    * @return addressFormat
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ADDRESS_FORMAT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -673,7 +653,6 @@ public class Country {
    * Get defaultPostalCodePattern
    * @return defaultPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -693,7 +672,6 @@ public class Country {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -708,7 +686,6 @@ public class Country {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -729,7 +706,6 @@ public class Country {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -763,7 +739,6 @@ public class Country {
    * Get states
    * @return states
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -864,4 +839,3 @@ public class Country {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryJsonApi.java
@@ -169,7 +169,6 @@ public class CountryJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -195,7 +194,6 @@ public class CountryJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -229,7 +227,6 @@ public class CountryJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +252,6 @@ public class CountryJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -289,7 +285,6 @@ public class CountryJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -323,7 +318,6 @@ public class CountryJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -349,7 +343,6 @@ public class CountryJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -375,7 +368,6 @@ public class CountryJsonApi {
    * Get iso
    * @return iso
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ISO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -401,7 +393,6 @@ public class CountryJsonApi {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -427,7 +418,6 @@ public class CountryJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -453,7 +443,6 @@ public class CountryJsonApi {
    * Get shippingAvailable
    * @return shippingAvailable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -479,7 +468,6 @@ public class CountryJsonApi {
    * Get iso3
    * @return iso3
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ISO3)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -505,7 +493,6 @@ public class CountryJsonApi {
    * Get displayStateInRegistration
    * @return displayStateInRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISPLAY_STATE_IN_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -531,7 +518,6 @@ public class CountryJsonApi {
    * Get forceStateInRegistration
    * @return forceStateInRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FORCE_STATE_IN_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -557,7 +543,6 @@ public class CountryJsonApi {
    * Get checkVatIdPattern
    * @return checkVatIdPattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_VAT_ID_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -583,7 +568,6 @@ public class CountryJsonApi {
    * Get vatIdRequired
    * @return vatIdRequired
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_ID_REQUIRED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -609,7 +593,6 @@ public class CountryJsonApi {
    * Get vatIdPattern
    * @return vatIdPattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_ID_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -635,7 +618,6 @@ public class CountryJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -661,7 +643,6 @@ public class CountryJsonApi {
    * Get customerTax
    * @return customerTax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -687,7 +668,6 @@ public class CountryJsonApi {
    * Get companyTax
    * @return companyTax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -713,7 +693,6 @@ public class CountryJsonApi {
    * Get postalCodeRequired
    * @return postalCodeRequired
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSTAL_CODE_REQUIRED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -739,7 +718,6 @@ public class CountryJsonApi {
    * Get checkPostalCodePattern
    * @return checkPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -765,7 +743,6 @@ public class CountryJsonApi {
    * Get checkAdvancedPostalCodePattern
    * @return checkAdvancedPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_ADVANCED_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -791,7 +768,6 @@ public class CountryJsonApi {
    * Get advancedPostalCodePattern
    * @return advancedPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADVANCED_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -817,7 +793,6 @@ public class CountryJsonApi {
    * Get addressFormat
    * @return addressFormat
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ADDRESS_FORMAT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -843,7 +818,6 @@ public class CountryJsonApi {
    * Get defaultPostalCodePattern
    * @return defaultPostalCodePattern
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_POSTAL_CODE_PATTERN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -863,7 +837,6 @@ public class CountryJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -878,7 +851,6 @@ public class CountryJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -899,7 +871,6 @@ public class CountryJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1008,4 +979,3 @@ public class CountryJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfCustomerTax.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfCustomerTax.java
@@ -53,7 +53,6 @@ public class CountryJsonApiAllOfCustomerTax {
    * Get enabled
    * @return enabled
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ENABLED)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class CountryJsonApiAllOfCustomerTax {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -105,7 +103,6 @@ public class CountryJsonApiAllOfCustomerTax {
    * Get amount
    * @return amount
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_AMOUNT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,4 +159,3 @@ public class CountryJsonApiAllOfCustomerTax {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationships.java
@@ -45,7 +45,6 @@ public class CountryJsonApiAllOfRelationships {
    * Get states
    * @return states
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CountryJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationshipsStates.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationshipsStates.java
@@ -51,7 +51,6 @@ public class CountryJsonApiAllOfRelationshipsStates {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class CountryJsonApiAllOfRelationshipsStates {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class CountryJsonApiAllOfRelationshipsStates {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationshipsStatesData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationshipsStatesData.java
@@ -49,7 +49,6 @@ public class CountryJsonApiAllOfRelationshipsStatesData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class CountryJsonApiAllOfRelationshipsStatesData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class CountryJsonApiAllOfRelationshipsStatesData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationshipsStatesLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryJsonApiAllOfRelationshipsStatesLinks.java
@@ -45,7 +45,6 @@ public class CountryJsonApiAllOfRelationshipsStatesLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class CountryJsonApiAllOfRelationshipsStatesLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryState.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryState.java
@@ -91,7 +91,6 @@ public class CountryState {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +116,6 @@ public class CountryState {
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -143,7 +141,6 @@ public class CountryState {
    * Get shortCode
    * @return shortCode
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHORT_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -169,7 +166,6 @@ public class CountryState {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -195,7 +191,6 @@ public class CountryState {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -221,7 +216,6 @@ public class CountryState {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -247,7 +241,6 @@ public class CountryState {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -267,7 +260,6 @@ public class CountryState {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -282,7 +274,6 @@ public class CountryState {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +294,6 @@ public class CountryState {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -374,4 +364,3 @@ public class CountryState {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CountryStateJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CountryStateJsonApi.java
@@ -116,7 +116,6 @@ public class CountryStateJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -142,7 +141,6 @@ public class CountryStateJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -176,7 +174,6 @@ public class CountryStateJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -202,7 +199,6 @@ public class CountryStateJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -244,7 +240,6 @@ public class CountryStateJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,7 +273,6 @@ public class CountryStateJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -304,7 +298,6 @@ public class CountryStateJsonApi {
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -330,7 +323,6 @@ public class CountryStateJsonApi {
    * Get shortCode
    * @return shortCode
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHORT_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -356,7 +348,6 @@ public class CountryStateJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -382,7 +373,6 @@ public class CountryStateJsonApi {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -408,7 +398,6 @@ public class CountryStateJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -434,7 +423,6 @@ public class CountryStateJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -454,7 +442,6 @@ public class CountryStateJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -469,7 +456,6 @@ public class CountryStateJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -490,7 +476,6 @@ public class CountryStateJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -582,4 +567,3 @@ public class CountryStateJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CreateOrderRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CreateOrderRequest.java
@@ -53,7 +53,6 @@ public class CreateOrderRequest {
    * Adds a comment from the customer to the order.
    * @return customerComment
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_COMMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -79,7 +78,6 @@ public class CreateOrderRequest {
    * The affiliate code can be used to track which referrer the customer came through. An example could be &#x60;Price-comparison-company-XY&#x60;.
    * @return affiliateCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFFILIATE_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class CreateOrderRequest {
    * The campaign code is used to track which action the customer came from. An example could be &#x60;Summer-Deals&#x60;
    * @return campaignCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAMPAIGN_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class CreateOrderRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Criteria.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Criteria.java
@@ -120,7 +120,6 @@ public class Criteria {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -146,7 +145,6 @@ public class Criteria {
    * Number of items per result page
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -180,7 +178,6 @@ public class Criteria {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -214,7 +211,6 @@ public class Criteria {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -248,7 +244,6 @@ public class Criteria {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -274,7 +269,6 @@ public class Criteria {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,7 +302,6 @@ public class Criteria {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -342,7 +335,6 @@ public class Criteria {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -376,7 +368,6 @@ public class Criteria {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -402,7 +393,6 @@ public class Criteria {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -473,4 +463,3 @@ public class Criteria {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CriteriaAggregationsInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CriteriaAggregationsInner.java
@@ -53,7 +53,6 @@ public class CriteriaAggregationsInner {
    * Give your aggregation an identifier, so you can find it easier
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class CriteriaAggregationsInner {
    * The type of aggregation
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -105,7 +103,6 @@ public class CriteriaAggregationsInner {
    * The field you want to aggregate over.
    * @return field
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIELD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,4 +159,3 @@ public class CriteriaAggregationsInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CriteriaFilterInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CriteriaFilterInner.java
@@ -53,7 +53,6 @@ public class CriteriaFilterInner {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class CriteriaFilterInner {
    * Get field
    * @return field
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIELD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -105,7 +103,6 @@ public class CriteriaFilterInner {
    * Get value
    * @return value
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,4 +159,3 @@ public class CriteriaFilterInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CriteriaSortInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CriteriaSortInner.java
@@ -53,7 +53,6 @@ public class CriteriaSortInner {
    * Get field
    * @return field
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIELD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class CriteriaSortInner {
    * Get order
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class CriteriaSortInner {
    * Get naturalSorting
    * @return naturalSorting
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NATURAL_SORTING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class CriteriaSortInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CrossSellingElementCollectionInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CrossSellingElementCollectionInner.java
@@ -55,7 +55,6 @@ public class CrossSellingElementCollectionInner {
    * Get crossSelling
    * @return crossSelling
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CROSS_SELLING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -89,7 +88,6 @@ public class CrossSellingElementCollectionInner {
    * Get products
    * @return products
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -115,7 +113,6 @@ public class CrossSellingElementCollectionInner {
    * Get total
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,4 +169,3 @@ public class CrossSellingElementCollectionInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CrossSellingElementCollectionInnerCrossSelling.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CrossSellingElementCollectionInnerCrossSelling.java
@@ -77,7 +77,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -103,7 +102,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -129,7 +127,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get sortBy
    * @return sortBy
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT_BY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -155,7 +152,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get sortDirection
    * @return sortDirection
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT_DIRECTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -181,7 +177,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get limit
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -207,7 +202,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -233,7 +227,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -259,7 +252,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get productStreamId
    * @return productStreamId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_STREAM_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +277,6 @@ public class CrossSellingElementCollectionInnerCrossSelling {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -354,4 +345,3 @@ public class CrossSellingElementCollectionInnerCrossSelling {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Currency.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Currency.java
@@ -111,7 +111,6 @@ public class Currency {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -137,7 +136,6 @@ public class Currency {
    * Get factor
    * @return factor
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FACTOR)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -163,7 +161,6 @@ public class Currency {
    * Get symbol
    * @return symbol
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SYMBOL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -189,7 +186,6 @@ public class Currency {
    * Get isoCode
    * @return isoCode
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ISO_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -215,7 +211,6 @@ public class Currency {
    * Get shortName
    * @return shortName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -241,7 +236,6 @@ public class Currency {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -267,7 +261,6 @@ public class Currency {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -293,7 +286,6 @@ public class Currency {
    * Runtime field, cannot be used as part of the criteria.
    * @return isSystemDefault
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_SYSTEM_DEFAULT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -319,7 +311,6 @@ public class Currency {
    * Get taxFreeFrom
    * @return taxFreeFrom
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_FREE_FROM)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -345,7 +336,6 @@ public class Currency {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -371,7 +361,6 @@ public class Currency {
    * Get itemRounding
    * @return itemRounding
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ITEM_ROUNDING)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -397,7 +386,6 @@ public class Currency {
    * Get totalRounding
    * @return totalRounding
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TOTAL_ROUNDING)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -417,7 +405,6 @@ public class Currency {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -432,7 +419,6 @@ public class Currency {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -453,7 +439,6 @@ public class Currency {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -534,4 +519,3 @@ public class Currency {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CurrencyCountryRounding.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CurrencyCountryRounding.java
@@ -63,7 +63,6 @@ public class CurrencyCountryRounding {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CurrencyCountryRounding {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CurrencyCountryRounding {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CurrencyCountryRounding {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CurrencyJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CurrencyJsonApi.java
@@ -136,7 +136,6 @@ public class CurrencyJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,7 +161,6 @@ public class CurrencyJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -196,7 +194,6 @@ public class CurrencyJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -222,7 +219,6 @@ public class CurrencyJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -264,7 +260,6 @@ public class CurrencyJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -298,7 +293,6 @@ public class CurrencyJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -324,7 +318,6 @@ public class CurrencyJsonApi {
    * Get factor
    * @return factor
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FACTOR)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -350,7 +343,6 @@ public class CurrencyJsonApi {
    * Get symbol
    * @return symbol
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SYMBOL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -376,7 +368,6 @@ public class CurrencyJsonApi {
    * Get isoCode
    * @return isoCode
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ISO_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -402,7 +393,6 @@ public class CurrencyJsonApi {
    * Get shortName
    * @return shortName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -428,7 +418,6 @@ public class CurrencyJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -454,7 +443,6 @@ public class CurrencyJsonApi {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -480,7 +468,6 @@ public class CurrencyJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return isSystemDefault
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_SYSTEM_DEFAULT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -506,7 +493,6 @@ public class CurrencyJsonApi {
    * Get taxFreeFrom
    * @return taxFreeFrom
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_FREE_FROM)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -532,7 +518,6 @@ public class CurrencyJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -558,7 +543,6 @@ public class CurrencyJsonApi {
    * Get itemRounding
    * @return itemRounding
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ITEM_ROUNDING)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -584,7 +568,6 @@ public class CurrencyJsonApi {
    * Get totalRounding
    * @return totalRounding
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TOTAL_ROUNDING)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -604,7 +587,6 @@ public class CurrencyJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -619,7 +601,6 @@ public class CurrencyJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -640,7 +621,6 @@ public class CurrencyJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -742,4 +722,3 @@ public class CurrencyJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CurrencyJsonApiAllOfItemRounding.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CurrencyJsonApiAllOfItemRounding.java
@@ -53,7 +53,6 @@ public class CurrencyJsonApiAllOfItemRounding {
    * Get decimals
    * @return decimals
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DECIMALS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -79,7 +78,6 @@ public class CurrencyJsonApiAllOfItemRounding {
    * Get interval
    * @return interval
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_INTERVAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class CurrencyJsonApiAllOfItemRounding {
    * Get roundForNet
    * @return roundForNet
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ROUND_FOR_NET)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class CurrencyJsonApiAllOfItemRounding {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomEntity.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomEntity.java
@@ -63,7 +63,6 @@ public class CustomEntity {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CustomEntity {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CustomEntity {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CustomEntity {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomField.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomField.java
@@ -63,7 +63,6 @@ public class CustomField {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CustomField {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CustomField {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CustomField {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomFieldSet.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomFieldSet.java
@@ -63,7 +63,6 @@ public class CustomFieldSet {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CustomFieldSet {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CustomFieldSet {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CustomFieldSet {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomFieldSetRelation.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomFieldSetRelation.java
@@ -63,7 +63,6 @@ public class CustomFieldSetRelation {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CustomFieldSetRelation {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CustomFieldSetRelation {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CustomFieldSetRelation {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Customer.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Customer.java
@@ -259,7 +259,6 @@ public class Customer {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +284,6 @@ public class Customer {
    * Get groupId
    * @return groupId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_GROUP_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -311,7 +309,6 @@ public class Customer {
    * Get defaultPaymentMethodId
    * @return defaultPaymentMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DEFAULT_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -337,7 +334,6 @@ public class Customer {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -363,7 +359,6 @@ public class Customer {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -389,7 +384,6 @@ public class Customer {
    * Get lastPaymentMethodId
    * @return lastPaymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -415,7 +409,6 @@ public class Customer {
    * Get defaultBillingAddressId
    * @return defaultBillingAddressId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DEFAULT_BILLING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -441,7 +434,6 @@ public class Customer {
    * Get defaultShippingAddressId
    * @return defaultShippingAddressId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DEFAULT_SHIPPING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -467,7 +459,6 @@ public class Customer {
    * Get customerNumber
    * @return customerNumber
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CUSTOMER_NUMBER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -493,7 +484,6 @@ public class Customer {
    * Get salutationId
    * @return salutationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -519,7 +509,6 @@ public class Customer {
    * Get firstName
    * @return firstName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -545,7 +534,6 @@ public class Customer {
    * Get lastName
    * @return lastName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -571,7 +559,6 @@ public class Customer {
    * Get company
    * @return company
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -597,7 +584,6 @@ public class Customer {
    * Get email
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -623,7 +609,6 @@ public class Customer {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -657,7 +642,6 @@ public class Customer {
    * Get vatIds
    * @return vatIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -683,7 +667,6 @@ public class Customer {
    * Get affiliateCode
    * @return affiliateCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFFILIATE_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -709,7 +692,6 @@ public class Customer {
    * Get campaignCode
    * @return campaignCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAMPAIGN_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -735,7 +717,6 @@ public class Customer {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -761,7 +742,6 @@ public class Customer {
    * Get doubleOptInRegistration
    * @return doubleOptInRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOUBLE_OPT_IN_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -787,7 +767,6 @@ public class Customer {
    * Get doubleOptInEmailSentDate
    * @return doubleOptInEmailSentDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOUBLE_OPT_IN_EMAIL_SENT_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -813,7 +792,6 @@ public class Customer {
    * Get doubleOptInConfirmDate
    * @return doubleOptInConfirmDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOUBLE_OPT_IN_CONFIRM_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -839,7 +817,6 @@ public class Customer {
    * Get hash
    * @return hash
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HASH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -865,7 +842,6 @@ public class Customer {
    * Get guest
    * @return guest
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GUEST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -891,7 +867,6 @@ public class Customer {
    * Get firstLogin
    * @return firstLogin
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST_LOGIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -917,7 +892,6 @@ public class Customer {
    * Get lastLogin
    * @return lastLogin
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_LOGIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -943,7 +917,6 @@ public class Customer {
    * Get birthday
    * @return birthday
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -963,7 +936,6 @@ public class Customer {
    * Get lastOrderDate
    * @return lastOrderDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_ORDER_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -978,7 +950,6 @@ public class Customer {
    * Get orderCount
    * @return orderCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -993,7 +964,6 @@ public class Customer {
    * Get orderTotalAmount
    * @return orderTotalAmount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_TOTAL_AMOUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1008,7 +978,6 @@ public class Customer {
    * Get reviewCount
    * @return reviewCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REVIEW_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1029,7 +998,6 @@ public class Customer {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1049,7 +1017,6 @@ public class Customer {
    * Get tagIds
    * @return tagIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAG_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1070,7 +1037,6 @@ public class Customer {
    * Get accountType
    * @return accountType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ACCOUNT_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1096,7 +1062,6 @@ public class Customer {
    * Get createdById
    * @return createdById
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CREATED_BY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1122,7 +1087,6 @@ public class Customer {
    * Get updatedById
    * @return updatedById
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_BY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1142,7 +1106,6 @@ public class Customer {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1157,7 +1120,6 @@ public class Customer {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1178,7 +1140,6 @@ public class Customer {
    * Get group
    * @return group
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1204,7 +1165,6 @@ public class Customer {
    * Get defaultPaymentMethod
    * @return defaultPaymentMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_PAYMENT_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1230,7 +1190,6 @@ public class Customer {
    * Get language
    * @return language
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1256,7 +1215,6 @@ public class Customer {
    * Get lastPaymentMethod
    * @return lastPaymentMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_PAYMENT_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1282,7 +1240,6 @@ public class Customer {
    * Get defaultBillingAddress
    * @return defaultBillingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_BILLING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1308,7 +1265,6 @@ public class Customer {
    * Get activeBillingAddress
    * @return activeBillingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE_BILLING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1334,7 +1290,6 @@ public class Customer {
    * Get defaultShippingAddress
    * @return defaultShippingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_SHIPPING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1360,7 +1315,6 @@ public class Customer {
    * Get activeShippingAddress
    * @return activeShippingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE_SHIPPING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1386,7 +1340,6 @@ public class Customer {
    * Get salutation
    * @return salutation
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1420,7 +1373,6 @@ public class Customer {
    * Get addresses
    * @return addresses
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADDRESSES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1454,7 +1406,6 @@ public class Customer {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1603,4 +1554,3 @@ public class Customer {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomerAddress.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomerAddress.java
@@ -139,7 +139,6 @@ public class CustomerAddress {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -165,7 +164,6 @@ public class CustomerAddress {
    * Get customerId
    * @return customerId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CUSTOMER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -191,7 +189,6 @@ public class CustomerAddress {
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +214,6 @@ public class CustomerAddress {
    * Get countryStateId
    * @return countryStateId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +239,6 @@ public class CustomerAddress {
    * Get salutationId
    * @return salutationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -269,7 +264,6 @@ public class CustomerAddress {
    * Get firstName
    * @return firstName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -295,7 +289,6 @@ public class CustomerAddress {
    * Get lastName
    * @return lastName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -321,7 +314,6 @@ public class CustomerAddress {
    * Get zipcode
    * @return zipcode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ZIPCODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -347,7 +339,6 @@ public class CustomerAddress {
    * Get city
    * @return city
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CITY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -373,7 +364,6 @@ public class CustomerAddress {
    * Get company
    * @return company
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -399,7 +389,6 @@ public class CustomerAddress {
    * Get street
    * @return street
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STREET)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -425,7 +414,6 @@ public class CustomerAddress {
    * Get department
    * @return department
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEPARTMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -451,7 +439,6 @@ public class CustomerAddress {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -477,7 +464,6 @@ public class CustomerAddress {
    * Get phoneNumber
    * @return phoneNumber
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PHONE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -503,7 +489,6 @@ public class CustomerAddress {
    * Get additionalAddressLine1
    * @return additionalAddressLine1
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADDITIONAL_ADDRESS_LINE1)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -529,7 +514,6 @@ public class CustomerAddress {
    * Get additionalAddressLine2
    * @return additionalAddressLine2
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADDITIONAL_ADDRESS_LINE2)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -555,7 +539,6 @@ public class CustomerAddress {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -575,7 +558,6 @@ public class CustomerAddress {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -590,7 +572,6 @@ public class CustomerAddress {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -611,7 +592,6 @@ public class CustomerAddress {
    * Get country
    * @return country
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -637,7 +617,6 @@ public class CustomerAddress {
    * Get countryState
    * @return countryState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -663,7 +642,6 @@ public class CustomerAddress {
    * Get salutation
    * @return salutation
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -758,4 +736,3 @@ public class CustomerAddress {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomerGroup.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomerGroup.java
@@ -99,7 +99,6 @@ public class CustomerGroup {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +124,6 @@ public class CustomerGroup {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -151,7 +149,6 @@ public class CustomerGroup {
    * Get displayGross
    * @return displayGross
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISPLAY_GROSS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +174,6 @@ public class CustomerGroup {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +199,6 @@ public class CustomerGroup {
    * Get registrationActive
    * @return registrationActive
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REGISTRATION_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +224,6 @@ public class CustomerGroup {
    * Get registrationTitle
    * @return registrationTitle
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REGISTRATION_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +249,6 @@ public class CustomerGroup {
    * Get registrationIntroduction
    * @return registrationIntroduction
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REGISTRATION_INTRODUCTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -281,7 +274,6 @@ public class CustomerGroup {
    * Get registrationOnlyCompanyRegistration
    * @return registrationOnlyCompanyRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REGISTRATION_ONLY_COMPANY_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -307,7 +299,6 @@ public class CustomerGroup {
    * Get registrationSeoMetaDescription
    * @return registrationSeoMetaDescription
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REGISTRATION_SEO_META_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -327,7 +318,6 @@ public class CustomerGroup {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -342,7 +332,6 @@ public class CustomerGroup {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +352,6 @@ public class CustomerGroup {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -438,4 +426,3 @@ public class CustomerGroup {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomerRecovery.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomerRecovery.java
@@ -63,7 +63,6 @@ public class CustomerRecovery {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class CustomerRecovery {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class CustomerRecovery {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class CustomerRecovery {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomerTag.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomerTag.java
@@ -55,7 +55,6 @@ public class CustomerTag {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -81,7 +80,6 @@ public class CustomerTag {
    * Get customerId
    * @return customerId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CUSTOMER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -107,7 +105,6 @@ public class CustomerTag {
    * Get tagId
    * @return tagId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAG_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -133,7 +130,6 @@ public class CustomerTag {
    * Get tag
    * @return tag
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -192,4 +188,3 @@ public class CustomerTag {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomerWishlist.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomerWishlist.java
@@ -71,7 +71,6 @@ public class CustomerWishlist {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class CustomerWishlist {
    * Get customerId
    * @return customerId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CUSTOMER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -123,7 +121,6 @@ public class CustomerWishlist {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -143,7 +140,6 @@ public class CustomerWishlist {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -158,7 +154,6 @@ public class CustomerWishlist {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -214,4 +209,3 @@ public class CustomerWishlist {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/CustomerWishlistProduct.java
+++ b/src/main/java/de/codebarista/shopware/model/core/CustomerWishlistProduct.java
@@ -71,7 +71,6 @@ public class CustomerWishlistProduct {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class CustomerWishlistProduct {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -123,7 +121,6 @@ public class CustomerWishlistProduct {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -143,7 +140,6 @@ public class CustomerWishlistProduct {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -158,7 +154,6 @@ public class CustomerWishlistProduct {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -214,4 +209,3 @@ public class CustomerWishlistProduct {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Data.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Data.java
@@ -70,7 +70,6 @@ public class Data {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -96,7 +95,6 @@ public class Data {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,7 +128,6 @@ public class Data {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -156,7 +153,6 @@ public class Data {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -198,7 +194,6 @@ public class Data {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -232,7 +227,6 @@ public class Data {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -306,4 +300,3 @@ public class Data {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/DeliveryTime.java
+++ b/src/main/java/de/codebarista/shopware/model/core/DeliveryTime.java
@@ -87,7 +87,6 @@ public class DeliveryTime {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -113,7 +112,6 @@ public class DeliveryTime {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -139,7 +137,6 @@ public class DeliveryTime {
    * Get min
    * @return min
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MIN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -165,7 +162,6 @@ public class DeliveryTime {
    * Get max
    * @return max
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MAX)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -191,7 +187,6 @@ public class DeliveryTime {
    * Get unit
    * @return unit
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_UNIT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +212,6 @@ public class DeliveryTime {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -237,7 +231,6 @@ public class DeliveryTime {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -252,7 +245,6 @@ public class DeliveryTime {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -273,7 +265,6 @@ public class DeliveryTime {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -342,4 +333,3 @@ public class DeliveryTime {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Document.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Document.java
@@ -136,7 +136,6 @@ public class Document {
      *
      * @return id
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +162,6 @@ public class Document {
      *
      * @return documentTypeId
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_DOCUMENT_TYPE_ID)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -190,7 +188,6 @@ public class Document {
      *
      * @return fileType
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_FILE_TYPE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +214,6 @@ public class Document {
      *
      * @return referencedDocumentId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_REFERENCED_DOCUMENT_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -244,7 +240,6 @@ public class Document {
      *
      * @return orderId
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_ORDER_ID)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -271,7 +266,6 @@ public class Document {
      *
      * @return documentMediaFileId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOCUMENT_MEDIA_FILE_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -298,7 +292,6 @@ public class Document {
      *
      * @return orderVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ORDER_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -324,7 +317,6 @@ public class Document {
      *
      * @return config
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CONFIG)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -351,7 +343,6 @@ public class Document {
      *
      * @return sent
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_SENT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -378,7 +369,6 @@ public class Document {
      *
      * @return _static
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_STATIC)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -405,7 +395,6 @@ public class Document {
      *
      * @return deepLinkCode
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_DEEP_LINK_CODE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -432,7 +421,6 @@ public class Document {
      *
      * @return documentNumber
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOCUMENT_NUMBER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -459,7 +447,6 @@ public class Document {
      *
      * @return customFields
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -480,7 +467,6 @@ public class Document {
      *
      * @return createdAt
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -494,7 +480,6 @@ public class Document {
      *
      * @return updatedAt
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UPDATED_AT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -514,7 +499,6 @@ public class Document {
      *
      * @return documentType
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOCUMENT_TYPE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -541,7 +525,6 @@ public class Document {
      *
      * @return order
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ORDER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -568,7 +551,6 @@ public class Document {
      *
      * @return referencedDocument
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_REFERENCED_DOCUMENT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -603,7 +585,6 @@ public class Document {
      *
      * @return dependentDocuments
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DEPENDENT_DOCUMENTS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -630,7 +611,6 @@ public class Document {
      *
      * @return documentMediaFile
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOCUMENT_MEDIA_FILE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/src/main/java/de/codebarista/shopware/model/core/DocumentBaseConfig.java
+++ b/src/main/java/de/codebarista/shopware/model/core/DocumentBaseConfig.java
@@ -104,7 +104,6 @@ public class DocumentBaseConfig {
      *
      * @return id
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -131,7 +130,6 @@ public class DocumentBaseConfig {
      *
      * @return documentTypeId
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_DOCUMENT_TYPE_ID)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -158,7 +156,6 @@ public class DocumentBaseConfig {
      *
      * @return logoId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_LOGO_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -185,7 +182,6 @@ public class DocumentBaseConfig {
      *
      * @return name
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_NAME)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -212,7 +208,6 @@ public class DocumentBaseConfig {
      *
      * @return filenamePrefix
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_FILENAME_PREFIX)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -239,7 +234,6 @@ public class DocumentBaseConfig {
      *
      * @return filenameSuffix
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_FILENAME_SUFFIX)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -266,7 +260,6 @@ public class DocumentBaseConfig {
      *
      * @return global
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_GLOBAL)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -293,7 +286,6 @@ public class DocumentBaseConfig {
      *
      * @return documentNumber
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOCUMENT_NUMBER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -320,7 +312,6 @@ public class DocumentBaseConfig {
      *
      * @return config
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CONFIG)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +332,6 @@ public class DocumentBaseConfig {
      *
      * @return createdAt
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -361,7 +351,6 @@ public class DocumentBaseConfig {
      *
      * @return customFields
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -382,7 +371,6 @@ public class DocumentBaseConfig {
      *
      * @return updatedAt
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UPDATED_AT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -402,7 +390,6 @@ public class DocumentBaseConfig {
      *
      * @return logo
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_LOGO)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -479,4 +466,3 @@ public class DocumentBaseConfig {
     }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/DocumentBaseConfigSalesChannel.java
+++ b/src/main/java/de/codebarista/shopware/model/core/DocumentBaseConfigSalesChannel.java
@@ -75,7 +75,6 @@ public class DocumentBaseConfigSalesChannel {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class DocumentBaseConfigSalesChannel {
    * Get documentBaseConfigId
    * @return documentBaseConfigId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DOCUMENT_BASE_CONFIG_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -127,7 +125,6 @@ public class DocumentBaseConfigSalesChannel {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +150,6 @@ public class DocumentBaseConfigSalesChannel {
    * Get documentTypeId
    * @return documentTypeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOCUMENT_TYPE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +169,6 @@ public class DocumentBaseConfigSalesChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -188,7 +183,6 @@ public class DocumentBaseConfigSalesChannel {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -246,4 +240,3 @@ public class DocumentBaseConfigSalesChannel {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/DocumentType.java
+++ b/src/main/java/de/codebarista/shopware/model/core/DocumentType.java
@@ -85,7 +85,6 @@ public class DocumentType {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -111,7 +110,6 @@ public class DocumentType {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -137,7 +135,6 @@ public class DocumentType {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -174,7 +171,6 @@ public class DocumentType {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -189,7 +185,6 @@ public class DocumentType {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -210,7 +205,6 @@ public class DocumentType {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -236,7 +230,6 @@ public class DocumentType {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/src/main/java/de/codebarista/shopware/model/core/EntitySearchResult.java
+++ b/src/main/java/de/codebarista/shopware/model/core/EntitySearchResult.java
@@ -65,7 +65,6 @@ public class EntitySearchResult {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -91,7 +90,6 @@ public class EntitySearchResult {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +115,6 @@ public class EntitySearchResult {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +148,6 @@ public class EntitySearchResult {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class EntitySearchResult {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class EntitySearchResult {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -266,4 +260,3 @@ public class EntitySearchResult {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Error.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Error.java
@@ -79,7 +79,6 @@ public class Error {
    * A unique identifier for this particular occurrence of the problem.
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -113,7 +112,6 @@ public class Error {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -139,7 +137,6 @@ public class Error {
    * The HTTP status code applicable to this problem, expressed as a string value.
    * @return status
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -165,7 +162,6 @@ public class Error {
    * An application-specific error code, expressed as a string value.
    * @return code
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -191,7 +187,6 @@ public class Error {
    * A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization.
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -217,7 +212,6 @@ public class Error {
    * A human-readable explanation specific to this occurrence of the problem.
    * @return detail
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DETAIL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class Error {
    * A human-readable description of the problem.
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -269,7 +262,6 @@ public class Error {
    * Get source
    * @return source
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SOURCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +295,6 @@ public class Error {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -372,4 +363,3 @@ public class Error {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ErrorSource.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ErrorSource.java
@@ -49,7 +49,6 @@ public class ErrorSource {
    * A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \&quot;/data\&quot; for a primary data object, or \&quot;/data/attributes/title\&quot; for a specific attribute].
    * @return pointer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POINTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ErrorSource {
    * A string indicating which query parameter caused the error.
    * @return parameter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARAMETER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ErrorSource {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Failure.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Failure.java
@@ -66,7 +66,6 @@ public class Failure {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -100,7 +99,6 @@ public class Failure {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -134,7 +132,6 @@ public class Failure {
    * Get errors
    * @return errors
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ERRORS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,4 +189,3 @@ public class Failure {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/FindProductVariantRouteResponse.java
+++ b/src/main/java/de/codebarista/shopware/model/core/FindProductVariantRouteResponse.java
@@ -43,7 +43,6 @@ public class FindProductVariantRouteResponse {
    * Get foundCombination
    * @return foundCombination
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOUND_COMBINATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -96,4 +95,3 @@ public class FindProductVariantRouteResponse {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/FindProductVariantRouteResponseFoundCombination.java
+++ b/src/main/java/de/codebarista/shopware/model/core/FindProductVariantRouteResponseFoundCombination.java
@@ -51,7 +51,6 @@ public class FindProductVariantRouteResponseFoundCombination {
    * Get variantId
    * @return variantId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VARIANT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class FindProductVariantRouteResponseFoundCombination {
    * Get options
    * @return options
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class FindProductVariantRouteResponseFoundCombination {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Flow.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Flow.java
@@ -63,7 +63,6 @@ public class Flow {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class Flow {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class Flow {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class Flow {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/FlowSequence.java
+++ b/src/main/java/de/codebarista/shopware/model/core/FlowSequence.java
@@ -63,7 +63,6 @@ public class FlowSequence {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class FlowSequence {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class FlowSequence {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class FlowSequence {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/FlowTemplate.java
+++ b/src/main/java/de/codebarista/shopware/model/core/FlowTemplate.java
@@ -63,7 +63,6 @@ public class FlowTemplate {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class FlowTemplate {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class FlowTemplate {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class FlowTemplate {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/GenerateJWTAppSystemAppServer200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/GenerateJWTAppSystemAppServer200Response.java
@@ -54,7 +54,6 @@ public class GenerateJWTAppSystemAppServer200Response {
    * Get token
    * @return token
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -80,7 +79,6 @@ public class GenerateJWTAppSystemAppServer200Response {
    * Get expires
    * @return expires
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EXPIRES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -106,7 +104,6 @@ public class GenerateJWTAppSystemAppServer200Response {
    * Get shopId
    * @return shopId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHOP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,4 +160,3 @@ public class GenerateJWTAppSystemAppServer200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/GetCustomerRecoveryIsExpiredRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/GetCustomerRecoveryIsExpiredRequest.java
@@ -45,7 +45,6 @@ public class GetCustomerRecoveryIsExpiredRequest {
    * Parameter from the link in the confirmation mail sent in Step 1
    * @return hash
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HASH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,4 +97,3 @@ public class GetCustomerRecoveryIsExpiredRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/HandlePaymentMethodRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/HandlePaymentMethodRequest.java
@@ -53,7 +53,6 @@ public class HandlePaymentMethodRequest {
    * Identifier of an order
    * @return orderId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class HandlePaymentMethodRequest {
    * URL to which the client should be redirected after successful payment
    * @return finishUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FINISH_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class HandlePaymentMethodRequest {
    * URL to which the client should be redirected after erroneous payment
    * @return errorUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ERROR_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class HandlePaymentMethodRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ImportExportFile.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ImportExportFile.java
@@ -63,7 +63,6 @@ public class ImportExportFile {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ImportExportFile {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ImportExportFile {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ImportExportFile {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ImportExportLog.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ImportExportLog.java
@@ -63,7 +63,6 @@ public class ImportExportLog {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ImportExportLog {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ImportExportLog {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ImportExportLog {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ImportExportProfile.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ImportExportProfile.java
@@ -67,7 +67,6 @@ public class ImportExportProfile {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class ImportExportProfile {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class ImportExportProfile {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class ImportExportProfile {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class ImportExportProfile {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Info.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Info.java
@@ -60,7 +60,6 @@ public class Info {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.ALWAYS)
 
@@ -94,7 +93,6 @@ public class Info {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -120,7 +118,6 @@ public class Info {
    * Get jsonapi
    * @return jsonapi
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_JSONAPI)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,4 +174,3 @@ public class Info {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Integration.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Integration.java
@@ -63,7 +63,6 @@ public class Integration {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class Integration {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class Integration {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class Integration {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Jsonapi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Jsonapi.java
@@ -51,7 +51,6 @@ public class Jsonapi {
    * Get version
    * @return version
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class Jsonapi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class Jsonapi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPage.java
@@ -121,7 +121,6 @@ public class LandingPage {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +146,6 @@ public class LandingPage {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +171,6 @@ public class LandingPage {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +196,6 @@ public class LandingPage {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -225,7 +221,6 @@ public class LandingPage {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +246,6 @@ public class LandingPage {
    * Get slotConfig
    * @return slotConfig
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SLOT_CONFIG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -277,7 +271,6 @@ public class LandingPage {
    * Get metaTitle
    * @return metaTitle
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +296,6 @@ public class LandingPage {
    * Get metaDescription
    * @return metaDescription
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -329,7 +321,6 @@ public class LandingPage {
    * Get keywords
    * @return keywords
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_KEYWORDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -355,7 +346,6 @@ public class LandingPage {
    * Get url
    * @return url
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -381,7 +371,6 @@ public class LandingPage {
    * Get cmsPageId
    * @return cmsPageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -407,7 +396,6 @@ public class LandingPage {
    * Get cmsPageVersionId
    * @return cmsPageVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -427,7 +415,6 @@ public class LandingPage {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -442,7 +429,6 @@ public class LandingPage {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -463,7 +449,6 @@ public class LandingPage {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -489,7 +474,6 @@ public class LandingPage {
    * Get cmsPage
    * @return cmsPage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -523,7 +507,6 @@ public class LandingPage {
    * Get seoUrls
    * @return seoUrls
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SEO_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -608,4 +591,3 @@ public class LandingPage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApi.java
@@ -133,7 +133,6 @@ public class LandingPageJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -159,7 +158,6 @@ public class LandingPageJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -193,7 +191,6 @@ public class LandingPageJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -219,7 +216,6 @@ public class LandingPageJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -253,7 +249,6 @@ public class LandingPageJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -287,7 +282,6 @@ public class LandingPageJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -313,7 +307,6 @@ public class LandingPageJsonApi {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -339,7 +332,6 @@ public class LandingPageJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -365,7 +357,6 @@ public class LandingPageJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -391,7 +382,6 @@ public class LandingPageJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -417,7 +407,6 @@ public class LandingPageJsonApi {
    * Get slotConfig
    * @return slotConfig
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SLOT_CONFIG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -443,7 +432,6 @@ public class LandingPageJsonApi {
    * Get metaTitle
    * @return metaTitle
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -469,7 +457,6 @@ public class LandingPageJsonApi {
    * Get metaDescription
    * @return metaDescription
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -495,7 +482,6 @@ public class LandingPageJsonApi {
    * Get keywords
    * @return keywords
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_KEYWORDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -521,7 +507,6 @@ public class LandingPageJsonApi {
    * Get url
    * @return url
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -547,7 +532,6 @@ public class LandingPageJsonApi {
    * Get cmsPageId
    * @return cmsPageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -573,7 +557,6 @@ public class LandingPageJsonApi {
    * Get cmsPageVersionId
    * @return cmsPageVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -593,7 +576,6 @@ public class LandingPageJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -608,7 +590,6 @@ public class LandingPageJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -629,7 +610,6 @@ public class LandingPageJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -720,4 +700,3 @@ public class LandingPageJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationships.java
@@ -49,7 +49,6 @@ public class LandingPageJsonApiAllOfRelationships {
    * Get cmsPage
    * @return cmsPage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LandingPageJsonApiAllOfRelationships {
    * Get seoUrls
    * @return seoUrls
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SEO_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LandingPageJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsCmsPage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsCmsPage.java
@@ -49,7 +49,6 @@ public class LandingPageJsonApiAllOfRelationshipsCmsPage {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LandingPageJsonApiAllOfRelationshipsCmsPage {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LandingPageJsonApiAllOfRelationshipsCmsPage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsCmsPageLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsCmsPageLinks.java
@@ -45,7 +45,6 @@ public class LandingPageJsonApiAllOfRelationshipsCmsPageLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class LandingPageJsonApiAllOfRelationshipsCmsPageLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsSeoUrls.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsSeoUrls.java
@@ -51,7 +51,6 @@ public class LandingPageJsonApiAllOfRelationshipsSeoUrls {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class LandingPageJsonApiAllOfRelationshipsSeoUrls {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class LandingPageJsonApiAllOfRelationshipsSeoUrls {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsSeoUrlsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LandingPageJsonApiAllOfRelationshipsSeoUrlsLinks.java
@@ -45,7 +45,6 @@ public class LandingPageJsonApiAllOfRelationshipsSeoUrlsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class LandingPageJsonApiAllOfRelationshipsSeoUrlsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Language.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Language.java
@@ -101,7 +101,6 @@ public class Language {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -127,7 +126,6 @@ public class Language {
    * Get parentId
    * @return parentId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +151,6 @@ public class Language {
    * Get localeId
    * @return localeId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LOCALE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -179,7 +176,6 @@ public class Language {
    * Get translationCodeId
    * @return translationCodeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATION_CODE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -205,7 +201,6 @@ public class Language {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -231,7 +226,6 @@ public class Language {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +245,6 @@ public class Language {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -266,7 +259,6 @@ public class Language {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -287,7 +279,6 @@ public class Language {
    * Get parent
    * @return parent
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -313,7 +304,6 @@ public class Language {
    * Get locale
    * @return locale
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LOCALE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -339,7 +329,6 @@ public class Language {
    * Get translationCode
    * @return translationCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATION_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -373,7 +362,6 @@ public class Language {
    * Get children
    * @return children
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILDREN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -448,4 +436,3 @@ public class Language {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApi.java
@@ -105,7 +105,6 @@ public class LanguageJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +130,6 @@ public class LanguageJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -165,7 +163,6 @@ public class LanguageJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -191,7 +188,6 @@ public class LanguageJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +221,6 @@ public class LanguageJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -259,7 +254,6 @@ public class LanguageJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +279,6 @@ public class LanguageJsonApi {
    * Get parentId
    * @return parentId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -311,7 +304,6 @@ public class LanguageJsonApi {
    * Get localeId
    * @return localeId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LOCALE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -337,7 +329,6 @@ public class LanguageJsonApi {
    * Get translationCodeId
    * @return translationCodeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATION_CODE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +354,6 @@ public class LanguageJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -389,7 +379,6 @@ public class LanguageJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -409,7 +398,6 @@ public class LanguageJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -424,7 +412,6 @@ public class LanguageJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -496,4 +483,3 @@ public class LanguageJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationships.java
@@ -57,7 +57,6 @@ public class LanguageJsonApiAllOfRelationships {
    * Get parent
    * @return parent
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class LanguageJsonApiAllOfRelationships {
    * Get locale
    * @return locale
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LOCALE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +107,6 @@ public class LanguageJsonApiAllOfRelationships {
    * Get translationCode
    * @return translationCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATION_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +132,6 @@ public class LanguageJsonApiAllOfRelationships {
    * Get children
    * @return children
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILDREN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,4 +190,3 @@ public class LanguageJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsChildren.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsChildren.java
@@ -51,7 +51,6 @@ public class LanguageJsonApiAllOfRelationshipsChildren {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class LanguageJsonApiAllOfRelationshipsChildren {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class LanguageJsonApiAllOfRelationshipsChildren {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsChildrenData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsChildrenData.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsChildrenData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsChildrenData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsChildrenData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsChildrenLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsChildrenLinks.java
@@ -45,7 +45,6 @@ public class LanguageJsonApiAllOfRelationshipsChildrenLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class LanguageJsonApiAllOfRelationshipsChildrenLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsLocale.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsLocale.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsLocale {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsLocale {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsLocale {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsLocaleData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsLocaleData.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsLocaleData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsLocaleData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsLocaleData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsLocaleLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsLocaleLinks.java
@@ -45,7 +45,6 @@ public class LanguageJsonApiAllOfRelationshipsLocaleLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class LanguageJsonApiAllOfRelationshipsLocaleLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsParent.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsParent.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsParent {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsParent {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsParent {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsParentData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsParentData.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsParentData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsParentData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsParentData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsParentLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsParentLinks.java
@@ -45,7 +45,6 @@ public class LanguageJsonApiAllOfRelationshipsParentLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class LanguageJsonApiAllOfRelationshipsParentLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsTranslationCode.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsTranslationCode.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCode {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCode {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCode {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsTranslationCodeData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsTranslationCodeData.java
@@ -49,7 +49,6 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCodeData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCodeData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCodeData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsTranslationCodeLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LanguageJsonApiAllOfRelationshipsTranslationCodeLinks.java
@@ -45,7 +45,6 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCodeLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class LanguageJsonApiAllOfRelationshipsTranslationCodeLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LineItem.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LineItem.java
@@ -79,7 +79,6 @@ public class LineItem {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class LineItem {
    * Get referencedId
    * @return referencedId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFERENCED_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -131,7 +129,6 @@ public class LineItem {
    * Get label
    * @return label
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LABEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class LineItem {
    * Get quantity
    * @return quantity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class LineItem {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class LineItem {
    * Get good
    * @return good
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GOOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -235,7 +229,6 @@ public class LineItem {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -261,7 +254,6 @@ public class LineItem {
    * Get removable
    * @return removable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REMOVABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -287,7 +279,6 @@ public class LineItem {
    * Get stackable
    * @return stackable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STACKABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -313,7 +304,6 @@ public class LineItem {
    * Get modified
    * @return modified
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MODIFIED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -384,4 +374,3 @@ public class LineItem {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Link.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Link.java
@@ -51,7 +51,6 @@ public class Link {
    * A string containing the link&#39;s URL.
    * @return href
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HREF)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -85,7 +84,6 @@ public class Link {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class Link {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LinkOneOf.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LinkOneOf.java
@@ -51,7 +51,6 @@ public class LinkOneOf {
    * A string containing the link&#39;s URL.
    * @return href
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HREF)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -85,7 +84,6 @@ public class LinkOneOf {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class LinkOneOf {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Linkage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Linkage.java
@@ -55,7 +55,6 @@ public class Linkage {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -81,7 +80,6 @@ public class Linkage {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -115,7 +113,6 @@ public class Linkage {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,4 +169,3 @@ public class Linkage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Locale.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Locale.java
@@ -83,7 +83,6 @@ public class Locale {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +108,6 @@ public class Locale {
    * Get code
    * @return code
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -135,7 +133,6 @@ public class Locale {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -161,7 +158,6 @@ public class Locale {
    * Get territory
    * @return territory
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TERRITORY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -187,7 +183,6 @@ public class Locale {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -207,7 +202,6 @@ public class Locale {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -222,7 +216,6 @@ public class Locale {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +236,6 @@ public class Locale {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -310,4 +302,3 @@ public class Locale {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LogEntry.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LogEntry.java
@@ -63,7 +63,6 @@ public class LogEntry {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class LogEntry {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class LogEntry {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class LogEntry {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/LoginCustomerRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/LoginCustomerRequest.java
@@ -49,7 +49,6 @@ public class LoginCustomerRequest {
    * Email
    * @return username
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_USERNAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -75,7 +74,6 @@ public class LoginCustomerRequest {
    * Password
    * @return password
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,4 +128,3 @@ public class LoginCustomerRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MailHeaderFooter.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MailHeaderFooter.java
@@ -95,7 +95,6 @@ public class MailHeaderFooter {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -121,7 +120,6 @@ public class MailHeaderFooter {
    * Get systemDefault
    * @return systemDefault
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SYSTEM_DEFAULT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +145,6 @@ public class MailHeaderFooter {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -173,7 +170,6 @@ public class MailHeaderFooter {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +195,6 @@ public class MailHeaderFooter {
    * Get headerHtml
    * @return headerHtml
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HEADER_HTML)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +220,6 @@ public class MailHeaderFooter {
    * Get headerPlain
    * @return headerPlain
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HEADER_PLAIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +245,6 @@ public class MailHeaderFooter {
    * Get footerHtml
    * @return footerHtml
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_HTML)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -277,7 +270,6 @@ public class MailHeaderFooter {
    * Get footerPlain
    * @return footerPlain
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_PLAIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -297,7 +289,6 @@ public class MailHeaderFooter {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -312,7 +303,6 @@ public class MailHeaderFooter {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -333,7 +323,6 @@ public class MailHeaderFooter {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,4 +395,3 @@ public class MailHeaderFooter {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MailTemplate.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MailTemplate.java
@@ -97,7 +97,6 @@ public class MailTemplate {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +122,6 @@ public class MailTemplate {
    * Get systemDefault
    * @return systemDefault
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SYSTEM_DEFAULT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -149,7 +147,6 @@ public class MailTemplate {
    * Get senderName
    * @return senderName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SENDER_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -175,7 +172,6 @@ public class MailTemplate {
    * Get contentHtml
    * @return contentHtml
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CONTENT_HTML)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -201,7 +197,6 @@ public class MailTemplate {
    * Get contentPlain
    * @return contentPlain
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CONTENT_PLAIN)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -227,7 +222,6 @@ public class MailTemplate {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -247,7 +241,6 @@ public class MailTemplate {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -262,7 +255,6 @@ public class MailTemplate {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -283,7 +275,6 @@ public class MailTemplate {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -309,7 +300,6 @@ public class MailTemplate {
    * Get mailTemplateType
    * @return mailTemplateType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAIL_TEMPLATE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -343,7 +333,6 @@ public class MailTemplate {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -416,4 +405,3 @@ public class MailTemplate {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MailTemplateMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MailTemplateMedia.java
@@ -63,7 +63,6 @@ public class MailTemplateMedia {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -89,7 +88,6 @@ public class MailTemplateMedia {
    * Get mailTemplateId
    * @return mailTemplateId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MAIL_TEMPLATE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -115,7 +113,6 @@ public class MailTemplateMedia {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -141,7 +138,6 @@ public class MailTemplateMedia {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -167,7 +163,6 @@ public class MailTemplateMedia {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -193,7 +188,6 @@ public class MailTemplateMedia {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -256,4 +250,3 @@ public class MailTemplateMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MailTemplateType.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MailTemplateType.java
@@ -79,7 +79,6 @@ public class MailTemplateType {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class MailTemplateType {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class MailTemplateType {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +154,6 @@ public class MailTemplateType {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class MailTemplateType {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,7 +187,6 @@ public class MailTemplateType {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +207,6 @@ public class MailTemplateType {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class MailTemplateType {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MainCategory.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MainCategory.java
@@ -83,7 +83,6 @@ public class MainCategory {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +108,6 @@ public class MainCategory {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -135,7 +133,6 @@ public class MainCategory {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -161,7 +158,6 @@ public class MainCategory {
    * Get categoryId
    * @return categoryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -187,7 +183,6 @@ public class MainCategory {
    * Get categoryVersionId
    * @return categoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +208,6 @@ public class MainCategory {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -233,7 +227,6 @@ public class MainCategory {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -248,7 +241,6 @@ public class MainCategory {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -310,4 +302,3 @@ public class MainCategory {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MainCategoryJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MainCategoryJsonApi.java
@@ -108,7 +108,6 @@ public class MainCategoryJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -134,7 +133,6 @@ public class MainCategoryJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -168,7 +166,6 @@ public class MainCategoryJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,7 +191,6 @@ public class MainCategoryJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -236,7 +232,6 @@ public class MainCategoryJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -270,7 +265,6 @@ public class MainCategoryJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -296,7 +290,6 @@ public class MainCategoryJsonApi {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -322,7 +315,6 @@ public class MainCategoryJsonApi {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -348,7 +340,6 @@ public class MainCategoryJsonApi {
    * Get categoryId
    * @return categoryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -374,7 +365,6 @@ public class MainCategoryJsonApi {
    * Get categoryVersionId
    * @return categoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -400,7 +390,6 @@ public class MainCategoryJsonApi {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -420,7 +409,6 @@ public class MainCategoryJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -435,7 +423,6 @@ public class MainCategoryJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -518,4 +505,3 @@ public class MainCategoryJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Media.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Media.java
@@ -137,7 +137,6 @@ public class Media {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +156,6 @@ public class Media {
    * Get mimeType
    * @return mimeType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIME_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,7 +170,6 @@ public class Media {
    * Get fileExtension
    * @return fileExtension
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILE_EXTENSION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -187,7 +184,6 @@ public class Media {
    * Get uploadedAt
    * @return uploadedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPLOADED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -202,7 +198,6 @@ public class Media {
    * Get fileName
    * @return fileName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -227,7 +222,6 @@ public class Media {
    * Get fileSize
    * @return fileSize
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILE_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -242,7 +236,6 @@ public class Media {
    * Get metaData
    * @return metaData
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -263,7 +256,6 @@ public class Media {
    * Get alt
    * @return alt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ALT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -289,7 +281,6 @@ public class Media {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -315,7 +306,6 @@ public class Media {
    * Runtime field, cannot be used as part of the criteria.
    * @return url
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +331,6 @@ public class Media {
    * Get path
    * @return path
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PATH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -367,7 +356,6 @@ public class Media {
    * Runtime field, cannot be used as part of the criteria.
    * @return hasFile
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HAS_FILE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -393,7 +381,6 @@ public class Media {
    * Get _private
    * @return _private
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRIVATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -419,7 +406,6 @@ public class Media {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -439,7 +425,6 @@ public class Media {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -454,7 +439,6 @@ public class Media {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -475,7 +459,6 @@ public class Media {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -509,7 +492,6 @@ public class Media {
    * Get thumbnails
    * @return thumbnails
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_THUMBNAILS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -596,4 +578,3 @@ public class Media {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MediaDefaultFolder.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MediaDefaultFolder.java
@@ -63,7 +63,6 @@ public class MediaDefaultFolder {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class MediaDefaultFolder {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class MediaDefaultFolder {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class MediaDefaultFolder {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MediaFolder.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MediaFolder.java
@@ -63,7 +63,6 @@ public class MediaFolder {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class MediaFolder {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class MediaFolder {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class MediaFolder {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MediaFolderConfiguration.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MediaFolderConfiguration.java
@@ -63,7 +63,6 @@ public class MediaFolderConfiguration {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class MediaFolderConfiguration {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class MediaFolderConfiguration {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class MediaFolderConfiguration {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MediaTag.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MediaTag.java
@@ -59,7 +59,6 @@ public class MediaTag {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class MediaTag {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -111,7 +109,6 @@ public class MediaTag {
    * Get tagId
    * @return tagId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAG_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -137,7 +134,6 @@ public class MediaTag {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +159,6 @@ public class MediaTag {
    * Get tag
    * @return tag
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -224,4 +219,3 @@ public class MediaTag {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MediaThumbnail.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MediaThumbnail.java
@@ -91,7 +91,6 @@ public class MediaThumbnail {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +116,6 @@ public class MediaThumbnail {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -137,7 +135,6 @@ public class MediaThumbnail {
    * Get width
    * @return width
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_WIDTH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -152,7 +149,6 @@ public class MediaThumbnail {
    * Get height
    * @return height
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -173,7 +169,6 @@ public class MediaThumbnail {
    * Runtime field, cannot be used as part of the criteria.
    * @return url
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +194,6 @@ public class MediaThumbnail {
    * Get path
    * @return path
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PATH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +219,6 @@ public class MediaThumbnail {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -245,7 +238,6 @@ public class MediaThumbnail {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -260,7 +252,6 @@ public class MediaThumbnail {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -324,4 +315,3 @@ public class MediaThumbnail {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MediaThumbnailSize.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MediaThumbnailSize.java
@@ -75,7 +75,6 @@ public class MediaThumbnailSize {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class MediaThumbnailSize {
    * Get width
    * @return width
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_WIDTH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -127,7 +125,6 @@ public class MediaThumbnailSize {
    * Get height
    * @return height
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -153,7 +150,6 @@ public class MediaThumbnailSize {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +169,6 @@ public class MediaThumbnailSize {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -188,7 +183,6 @@ public class MediaThumbnailSize {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -246,4 +240,3 @@ public class MediaThumbnailSize {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/MergeProductOnWishlistRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/MergeProductOnWishlistRequest.java
@@ -55,7 +55,6 @@ public class MergeProductOnWishlistRequest {
    * List product id
    * @return productIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -108,4 +107,3 @@ public class MergeProductOnWishlistRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/NewsletterRecipient.java
+++ b/src/main/java/de/codebarista/shopware/model/core/NewsletterRecipient.java
@@ -63,7 +63,6 @@ public class NewsletterRecipient {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class NewsletterRecipient {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class NewsletterRecipient {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class NewsletterRecipient {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/NewsletterRecipientJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/NewsletterRecipientJsonApi.java
@@ -88,7 +88,6 @@ public class NewsletterRecipientJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -114,7 +113,6 @@ public class NewsletterRecipientJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -148,7 +146,6 @@ public class NewsletterRecipientJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -174,7 +171,6 @@ public class NewsletterRecipientJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -216,7 +212,6 @@ public class NewsletterRecipientJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -250,7 +245,6 @@ public class NewsletterRecipientJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -270,7 +264,6 @@ public class NewsletterRecipientJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -285,7 +278,6 @@ public class NewsletterRecipientJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -358,4 +350,3 @@ public class NewsletterRecipientJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Notification.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Notification.java
@@ -63,7 +63,6 @@ public class Notification {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class Notification {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class Notification {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class Notification {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/NumberRange.java
+++ b/src/main/java/de/codebarista/shopware/model/core/NumberRange.java
@@ -67,7 +67,6 @@ public class NumberRange {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class NumberRange {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class NumberRange {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class NumberRange {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class NumberRange {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/NumberRangeSalesChannel.java
+++ b/src/main/java/de/codebarista/shopware/model/core/NumberRangeSalesChannel.java
@@ -63,7 +63,6 @@ public class NumberRangeSalesChannel {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class NumberRangeSalesChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class NumberRangeSalesChannel {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class NumberRangeSalesChannel {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/NumberRangeState.java
+++ b/src/main/java/de/codebarista/shopware/model/core/NumberRangeState.java
@@ -63,7 +63,6 @@ public class NumberRangeState {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class NumberRangeState {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class NumberRangeState {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class NumberRangeState {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/NumberRangeType.java
+++ b/src/main/java/de/codebarista/shopware/model/core/NumberRangeType.java
@@ -67,7 +67,6 @@ public class NumberRangeType {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class NumberRangeType {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class NumberRangeType {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class NumberRangeType {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class NumberRangeType {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Order.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Order.java
@@ -222,7 +222,6 @@ public class Order {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -248,7 +247,6 @@ public class Order {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -274,7 +272,6 @@ public class Order {
    * Get orderNumber
    * @return orderNumber
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -300,7 +297,6 @@ public class Order {
    * Get billingAddressId
    * @return billingAddressId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_BILLING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -326,7 +322,6 @@ public class Order {
    * Get billingAddressVersionId
    * @return billingAddressVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BILLING_ADDRESS_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -352,7 +347,6 @@ public class Order {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -378,7 +372,6 @@ public class Order {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -404,7 +397,6 @@ public class Order {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -430,7 +422,6 @@ public class Order {
    * Get orderDateTime
    * @return orderDateTime
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_DATE_TIME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -450,7 +441,6 @@ public class Order {
    * Get orderDate
    * @return orderDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -471,7 +461,6 @@ public class Order {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -491,7 +480,6 @@ public class Order {
    * Get amountTotal
    * @return amountTotal
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AMOUNT_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -506,7 +494,6 @@ public class Order {
    * Get amountNet
    * @return amountNet
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AMOUNT_NET)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -521,7 +508,6 @@ public class Order {
    * Get positionPrice
    * @return positionPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -536,7 +522,6 @@ public class Order {
    * Get taxStatus
    * @return taxStatus
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -557,7 +542,6 @@ public class Order {
    * Get shippingCosts
    * @return shippingCosts
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_COSTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -577,7 +561,6 @@ public class Order {
    * Get shippingTotal
    * @return shippingTotal
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -598,7 +581,6 @@ public class Order {
    * Get currencyFactor
    * @return currencyFactor
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CURRENCY_FACTOR)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -624,7 +606,6 @@ public class Order {
    * Get deepLinkCode
    * @return deepLinkCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEEP_LINK_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -650,7 +631,6 @@ public class Order {
    * Get affiliateCode
    * @return affiliateCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFFILIATE_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -676,7 +656,6 @@ public class Order {
    * Get campaignCode
    * @return campaignCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAMPAIGN_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -702,7 +681,6 @@ public class Order {
    * Get customerComment
    * @return customerComment
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_COMMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -728,7 +706,6 @@ public class Order {
    * Get source
    * @return source
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SOURCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -754,7 +731,6 @@ public class Order {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -780,7 +756,6 @@ public class Order {
    * Get createdById
    * @return createdById
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CREATED_BY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -806,7 +781,6 @@ public class Order {
    * Get updatedById
    * @return updatedById
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_BY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -826,7 +800,6 @@ public class Order {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -841,7 +814,6 @@ public class Order {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -862,7 +834,6 @@ public class Order {
    * Get stateMachineState
    * @return stateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -888,7 +859,6 @@ public class Order {
    * Get orderCustomer
    * @return orderCustomer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_CUSTOMER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -914,7 +884,6 @@ public class Order {
    * Get currency
    * @return currency
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -940,7 +909,6 @@ public class Order {
    * Get language
    * @return language
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -974,7 +942,6 @@ public class Order {
    * Get addresses
    * @return addresses
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADDRESSES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1000,7 +967,6 @@ public class Order {
    * Get billingAddress
    * @return billingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BILLING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1034,7 +1000,6 @@ public class Order {
    * Get deliveries
    * @return deliveries
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1068,7 +1033,6 @@ public class Order {
    * Get lineItems
    * @return lineItems
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINE_ITEMS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1102,7 +1066,6 @@ public class Order {
    * Get transactions
    * @return transactions
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSACTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1136,7 +1099,6 @@ public class Order {
    * Get documents
    * @return documents
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOCUMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1170,7 +1132,6 @@ public class Order {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/src/main/java/de/codebarista/shopware/model/core/OrderAddress.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderAddress.java
@@ -139,7 +139,6 @@ public class OrderAddress {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -165,7 +164,6 @@ public class OrderAddress {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -191,7 +189,6 @@ public class OrderAddress {
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +214,6 @@ public class OrderAddress {
    * Get countryStateId
    * @return countryStateId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +239,6 @@ public class OrderAddress {
    * Get firstName
    * @return firstName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -269,7 +264,6 @@ public class OrderAddress {
    * Get lastName
    * @return lastName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -295,7 +289,6 @@ public class OrderAddress {
    * Get street
    * @return street
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STREET)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -321,7 +314,6 @@ public class OrderAddress {
    * Get zipcode
    * @return zipcode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ZIPCODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -347,7 +339,6 @@ public class OrderAddress {
    * Get city
    * @return city
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CITY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -373,7 +364,6 @@ public class OrderAddress {
    * Get company
    * @return company
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -399,7 +389,6 @@ public class OrderAddress {
    * Get department
    * @return department
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEPARTMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -425,7 +414,6 @@ public class OrderAddress {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -451,7 +439,6 @@ public class OrderAddress {
    * Get vatId
    * @return vatId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -477,7 +464,6 @@ public class OrderAddress {
    * Get phoneNumber
    * @return phoneNumber
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PHONE_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -503,7 +489,6 @@ public class OrderAddress {
    * Get additionalAddressLine1
    * @return additionalAddressLine1
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADDITIONAL_ADDRESS_LINE1)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -529,7 +514,6 @@ public class OrderAddress {
    * Get additionalAddressLine2
    * @return additionalAddressLine2
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ADDITIONAL_ADDRESS_LINE2)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -555,7 +539,6 @@ public class OrderAddress {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -575,7 +558,6 @@ public class OrderAddress {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -590,7 +572,6 @@ public class OrderAddress {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -611,7 +592,6 @@ public class OrderAddress {
    * Get country
    * @return country
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -637,7 +617,6 @@ public class OrderAddress {
    * Get countryState
    * @return countryState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -663,7 +642,6 @@ public class OrderAddress {
    * Get salutation
    * @return salutation
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -758,4 +736,3 @@ public class OrderAddress {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderCustomer.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderCustomer.java
@@ -112,7 +112,6 @@ public class OrderCustomer {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -138,7 +137,6 @@ public class OrderCustomer {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -164,7 +162,6 @@ public class OrderCustomer {
    * Get email
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -190,7 +187,6 @@ public class OrderCustomer {
    * Get salutationId
    * @return salutationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -216,7 +212,6 @@ public class OrderCustomer {
    * Get firstName
    * @return firstName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -242,7 +237,6 @@ public class OrderCustomer {
    * Get lastName
    * @return lastName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -268,7 +262,6 @@ public class OrderCustomer {
    * Get company
    * @return company
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -294,7 +287,6 @@ public class OrderCustomer {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -328,7 +320,6 @@ public class OrderCustomer {
    * Get vatIds
    * @return vatIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VAT_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -354,7 +345,6 @@ public class OrderCustomer {
    * Get customerNumber
    * @return customerNumber
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -380,7 +370,6 @@ public class OrderCustomer {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -400,7 +389,6 @@ public class OrderCustomer {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -415,7 +403,6 @@ public class OrderCustomer {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -436,7 +423,6 @@ public class OrderCustomer {
    * Get salutation
    * @return salutation
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -455,7 +441,6 @@ public class OrderCustomer {
    * Get customer ID
    * @return customer ID
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -534,4 +519,3 @@ public class OrderCustomer {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderDelivery.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderDelivery.java
@@ -129,7 +129,6 @@ public class OrderDelivery {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -155,7 +154,6 @@ public class OrderDelivery {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -181,7 +179,6 @@ public class OrderDelivery {
    * Get orderId
    * @return orderId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -207,7 +204,6 @@ public class OrderDelivery {
    * Get orderVersionId
    * @return orderVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -233,7 +229,6 @@ public class OrderDelivery {
    * Get shippingOrderAddressId
    * @return shippingOrderAddressId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHIPPING_ORDER_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -259,7 +254,6 @@ public class OrderDelivery {
    * Get shippingOrderAddressVersionId
    * @return shippingOrderAddressVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_ORDER_ADDRESS_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +279,6 @@ public class OrderDelivery {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -311,7 +304,6 @@ public class OrderDelivery {
    * Get stateId
    * @return stateId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -345,7 +337,6 @@ public class OrderDelivery {
    * Get trackingCodes
    * @return trackingCodes
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TRACKING_CODES)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -371,7 +362,6 @@ public class OrderDelivery {
    * Get shippingDateEarliest
    * @return shippingDateEarliest
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHIPPING_DATE_EARLIEST)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -397,7 +387,6 @@ public class OrderDelivery {
    * Get shippingDateLatest
    * @return shippingDateLatest
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHIPPING_DATE_LATEST)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -423,7 +412,6 @@ public class OrderDelivery {
    * Get shippingCosts
    * @return shippingCosts
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_COSTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -449,7 +437,6 @@ public class OrderDelivery {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -469,7 +456,6 @@ public class OrderDelivery {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -484,7 +470,6 @@ public class OrderDelivery {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -505,7 +490,6 @@ public class OrderDelivery {
    * Get stateMachineState
    * @return stateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -531,7 +515,6 @@ public class OrderDelivery {
    * Get shippingOrderAddress
    * @return shippingOrderAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_ORDER_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -557,7 +540,6 @@ public class OrderDelivery {
    * Get shippingMethod
    * @return shippingMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -591,7 +573,6 @@ public class OrderDelivery {
    * Get positions
    * @return positions
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -680,4 +661,3 @@ public class OrderDelivery {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderDeliveryPosition.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderDeliveryPosition.java
@@ -103,7 +103,6 @@ public class OrderDeliveryPosition {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -129,7 +128,6 @@ public class OrderDeliveryPosition {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -155,7 +153,6 @@ public class OrderDeliveryPosition {
    * Get orderDeliveryId
    * @return orderDeliveryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_DELIVERY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -181,7 +178,6 @@ public class OrderDeliveryPosition {
    * Get orderDeliveryVersionId
    * @return orderDeliveryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_DELIVERY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -207,7 +203,6 @@ public class OrderDeliveryPosition {
    * Get orderLineItemId
    * @return orderLineItemId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -233,7 +228,6 @@ public class OrderDeliveryPosition {
    * Get orderLineItemVersionId
    * @return orderLineItemVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -259,7 +253,6 @@ public class OrderDeliveryPosition {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +278,6 @@ public class OrderDeliveryPosition {
    * Get unitPrice
    * @return unitPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UNIT_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -311,7 +303,6 @@ public class OrderDeliveryPosition {
    * Get totalPrice
    * @return totalPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +328,6 @@ public class OrderDeliveryPosition {
    * Get quantity
    * @return quantity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +353,6 @@ public class OrderDeliveryPosition {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -383,7 +372,6 @@ public class OrderDeliveryPosition {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -398,7 +386,6 @@ public class OrderDeliveryPosition {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -470,4 +457,3 @@ public class OrderDeliveryPosition {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderLineItem.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderLineItem.java
@@ -187,7 +187,6 @@ public class OrderLineItem {
      *
      * @return id
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public String getId() {
@@ -201,7 +200,6 @@ public class OrderLineItem {
         this.id = id;
     }
 
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRICE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
     public CalculatedPrice getPrice() {
@@ -227,7 +225,6 @@ public class OrderLineItem {
      *
      * @return versionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -254,7 +251,6 @@ public class OrderLineItem {
      *
      * @return orderId
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_ORDER_ID)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -281,7 +277,6 @@ public class OrderLineItem {
      *
      * @return orderVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ORDER_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,7 +303,6 @@ public class OrderLineItem {
      *
      * @return productId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -335,7 +329,6 @@ public class OrderLineItem {
      *
      * @return productVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -362,7 +355,6 @@ public class OrderLineItem {
      *
      * @return parentId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PARENT_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -389,7 +381,6 @@ public class OrderLineItem {
      *
      * @return parentVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PARENT_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -416,7 +407,6 @@ public class OrderLineItem {
      *
      * @return coverId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_COVER_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -443,7 +433,6 @@ public class OrderLineItem {
      *
      * @return identifier
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_IDENTIFIER)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -470,7 +459,6 @@ public class OrderLineItem {
      *
      * @return referencedId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_REFERENCED_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -497,7 +485,6 @@ public class OrderLineItem {
      *
      * @return quantity
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_QUANTITY)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -524,7 +511,6 @@ public class OrderLineItem {
      *
      * @return label
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_LABEL)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -551,7 +537,6 @@ public class OrderLineItem {
      *
      * @return payload
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PAYLOAD)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -578,7 +563,6 @@ public class OrderLineItem {
      *
      * @return good
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_GOOD)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -605,7 +589,6 @@ public class OrderLineItem {
      *
      * @return removable
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_REMOVABLE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -632,7 +615,6 @@ public class OrderLineItem {
      *
      * @return stackable
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_STACKABLE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -659,7 +641,6 @@ public class OrderLineItem {
      *
      * @return position
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_POSITION)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -694,7 +675,6 @@ public class OrderLineItem {
      *
      * @return states
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_STATES)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -721,7 +701,6 @@ public class OrderLineItem {
      *
      * @return priceDefinition
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRICE_DEFINITION)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -748,7 +727,6 @@ public class OrderLineItem {
      *
      * @return unitPrice
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UNIT_PRICE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -775,7 +753,6 @@ public class OrderLineItem {
      *
      * @return totalPrice
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TOTAL_PRICE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -802,7 +779,6 @@ public class OrderLineItem {
      *
      * @return description
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DESCRIPTION)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -829,7 +805,6 @@ public class OrderLineItem {
      *
      * @return type
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TYPE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -856,7 +831,6 @@ public class OrderLineItem {
      *
      * @return customFields
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -877,7 +851,6 @@ public class OrderLineItem {
      *
      * @return createdAt
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -891,7 +864,6 @@ public class OrderLineItem {
      *
      * @return updatedAt
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UPDATED_AT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -911,7 +883,6 @@ public class OrderLineItem {
      *
      * @return cover
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_COVER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -946,7 +917,6 @@ public class OrderLineItem {
      *
      * @return orderDeliveryPositions
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ORDER_DELIVERY_POSITIONS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -981,7 +951,6 @@ public class OrderLineItem {
      *
      * @return downloads
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOWNLOADS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1008,7 +977,6 @@ public class OrderLineItem {
      *
      * @return parent
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PARENT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1043,7 +1011,6 @@ public class OrderLineItem {
      *
      * @return children
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CHILDREN)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 

--- a/src/main/java/de/codebarista/shopware/model/core/OrderLineItemDownload.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderLineItemDownload.java
@@ -99,7 +99,6 @@ public class OrderLineItemDownload {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +124,6 @@ public class OrderLineItemDownload {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +149,6 @@ public class OrderLineItemDownload {
    * Get orderLineItemId
    * @return orderLineItemId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -177,7 +174,6 @@ public class OrderLineItemDownload {
    * Get orderLineItemVersionId
    * @return orderLineItemVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +199,6 @@ public class OrderLineItemDownload {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -229,7 +224,6 @@ public class OrderLineItemDownload {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -255,7 +249,6 @@ public class OrderLineItemDownload {
    * Get accessGranted
    * @return accessGranted
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ACCESS_GRANTED)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -281,7 +274,6 @@ public class OrderLineItemDownload {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -301,7 +293,6 @@ public class OrderLineItemDownload {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -316,7 +307,6 @@ public class OrderLineItemDownload {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +327,6 @@ public class OrderLineItemDownload {
    * Get orderLineItem
    * @return orderLineItem
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +352,6 @@ public class OrderLineItemDownload {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -438,4 +426,3 @@ public class OrderLineItemDownload {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderPrice.java
@@ -73,7 +73,6 @@ public class OrderPrice {
      *
      * @return netPrice
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_NET_PRICE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -100,7 +99,6 @@ public class OrderPrice {
      *
      * @return totalPrice
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_TOTAL_PRICE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -127,7 +125,6 @@ public class OrderPrice {
      *
      * @return calculatedTaxes
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CALCULATED_TAXES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -154,7 +151,6 @@ public class OrderPrice {
      *
      * @return taxRules
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TAX_RULES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -181,7 +177,6 @@ public class OrderPrice {
      *
      * @return positionPrice
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_POSITION_PRICE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -208,7 +203,6 @@ public class OrderPrice {
      *
      * @return rawTotal
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_RAW_TOTAL)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -235,7 +229,6 @@ public class OrderPrice {
      *
      * @return taxStatus
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_TAX_STATUS)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 

--- a/src/main/java/de/codebarista/shopware/model/core/OrderRouteResponse.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderRouteResponse.java
@@ -59,7 +59,6 @@ public class OrderRouteResponse {
    * Get orders
    * @return orders
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -93,7 +92,6 @@ public class OrderRouteResponse {
    * The key-value pairs contain the uuid of the order as key and a boolean as value, indicating that the payment method can still be changed.
    * @return paymentChangeable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_CHANGEABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -148,4 +146,3 @@ public class OrderRouteResponse {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderSetPaymentRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderSetPaymentRequest.java
@@ -49,7 +49,6 @@ public class OrderSetPaymentRequest {
    * The identifier of the paymentMethod to be set
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -75,7 +74,6 @@ public class OrderSetPaymentRequest {
    * The identifier of the order.
    * @return orderId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,4 +128,3 @@ public class OrderSetPaymentRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderShippingCosts.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderShippingCosts.java
@@ -73,7 +73,6 @@ public class OrderShippingCosts {
    * Get unitPrice
    * @return unitPrice
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_UNIT_PRICE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -99,7 +98,6 @@ public class OrderShippingCosts {
    * Get totalPrice
    * @return totalPrice
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TOTAL_PRICE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -125,7 +123,6 @@ public class OrderShippingCosts {
    * Get quantity
    * @return quantity
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_QUANTITY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -151,7 +148,6 @@ public class OrderShippingCosts {
    * Get calculatedTaxes
    * @return calculatedTaxes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATED_TAXES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class OrderShippingCosts {
    * Get taxRules
    * @return taxRules
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_RULES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class OrderShippingCosts {
    * Get referencePrice
    * @return referencePrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFERENCE_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +223,6 @@ public class OrderShippingCosts {
    * Get listPrice
    * @return listPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIST_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +248,6 @@ public class OrderShippingCosts {
    * Get regulationPrice
    * @return regulationPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REGULATION_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,4 +314,3 @@ public class OrderShippingCosts {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderShippingCostsListPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderShippingCostsListPrice.java
@@ -53,7 +53,6 @@ public class OrderShippingCostsListPrice {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -79,7 +78,6 @@ public class OrderShippingCostsListPrice {
    * Get discount
    * @return discount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISCOUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class OrderShippingCostsListPrice {
    * Get percentage
    * @return percentage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PERCENTAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class OrderShippingCostsListPrice {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderShippingCostsRegulationPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderShippingCostsRegulationPrice.java
@@ -45,7 +45,6 @@ public class OrderShippingCostsRegulationPrice {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class OrderShippingCostsRegulationPrice {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderTag.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderTag.java
@@ -63,7 +63,6 @@ public class OrderTag {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -89,7 +88,6 @@ public class OrderTag {
    * Get orderId
    * @return orderId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -115,7 +113,6 @@ public class OrderTag {
    * Get orderVersionId
    * @return orderVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -141,7 +138,6 @@ public class OrderTag {
    * Get tagId
    * @return tagId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAG_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -167,7 +163,6 @@ public class OrderTag {
    * Get order
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -193,7 +188,6 @@ public class OrderTag {
    * Get tag
    * @return tag
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -256,4 +250,3 @@ public class OrderTag {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderTransaction.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderTransaction.java
@@ -106,7 +106,6 @@ public class OrderTransaction {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -132,7 +131,6 @@ public class OrderTransaction {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -158,7 +156,6 @@ public class OrderTransaction {
    * Get orderId
    * @return orderId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -184,7 +181,6 @@ public class OrderTransaction {
    * Get orderVersionId
    * @return orderVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -210,7 +206,6 @@ public class OrderTransaction {
    * Get paymentMethodId
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -236,7 +231,6 @@ public class OrderTransaction {
    * Get amount
    * @return amount
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_AMOUNT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -262,7 +256,6 @@ public class OrderTransaction {
    * Get stateId
    * @return stateId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -288,7 +281,6 @@ public class OrderTransaction {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,7 +300,6 @@ public class OrderTransaction {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -323,7 +314,6 @@ public class OrderTransaction {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -344,7 +334,6 @@ public class OrderTransaction {
    * Get stateMachineState
    * @return stateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -370,7 +359,6 @@ public class OrderTransaction {
    * Get paymentMethod
    * @return paymentMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -404,7 +392,6 @@ public class OrderTransaction {
    * Get captures
    * @return captures
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAPTURES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 

--- a/src/main/java/de/codebarista/shopware/model/core/OrderTransactionCapture.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderTransactionCapture.java
@@ -105,7 +105,6 @@ public class OrderTransactionCapture {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -131,7 +130,6 @@ public class OrderTransactionCapture {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +155,6 @@ public class OrderTransactionCapture {
    * Get orderTransactionId
    * @return orderTransactionId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_TRANSACTION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -183,7 +180,6 @@ public class OrderTransactionCapture {
    * Get orderTransactionVersionId
    * @return orderTransactionVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_TRANSACTION_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +205,6 @@ public class OrderTransactionCapture {
    * Get stateId
    * @return stateId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -235,7 +230,6 @@ public class OrderTransactionCapture {
    * Get externalReference
    * @return externalReference
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -261,7 +255,6 @@ public class OrderTransactionCapture {
    * Get amount
    * @return amount
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_AMOUNT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -287,7 +280,6 @@ public class OrderTransactionCapture {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -307,7 +299,6 @@ public class OrderTransactionCapture {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -322,7 +313,6 @@ public class OrderTransactionCapture {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -343,7 +333,6 @@ public class OrderTransactionCapture {
    * Get stateMachineState
    * @return stateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -369,7 +358,6 @@ public class OrderTransactionCapture {
    * Get transaction
    * @return transaction
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSACTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -403,7 +391,6 @@ public class OrderTransactionCapture {
    * Get refunds
    * @return refunds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFUNDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -480,4 +467,3 @@ public class OrderTransactionCapture {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderTransactionCaptureRefund.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderTransactionCaptureRefund.java
@@ -109,7 +109,6 @@ public class OrderTransactionCaptureRefund {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +134,6 @@ public class OrderTransactionCaptureRefund {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -161,7 +159,6 @@ public class OrderTransactionCaptureRefund {
    * Get captureId
    * @return captureId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CAPTURE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -187,7 +184,6 @@ public class OrderTransactionCaptureRefund {
    * Get captureVersionId
    * @return captureVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAPTURE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +209,6 @@ public class OrderTransactionCaptureRefund {
    * Get stateId
    * @return stateId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -239,7 +234,6 @@ public class OrderTransactionCaptureRefund {
    * Get externalReference
    * @return externalReference
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -265,7 +259,6 @@ public class OrderTransactionCaptureRefund {
    * Get reason
    * @return reason
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REASON)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -291,7 +284,6 @@ public class OrderTransactionCaptureRefund {
    * Get amount
    * @return amount
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_AMOUNT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -317,7 +309,6 @@ public class OrderTransactionCaptureRefund {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +328,6 @@ public class OrderTransactionCaptureRefund {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -352,7 +342,6 @@ public class OrderTransactionCaptureRefund {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -373,7 +362,6 @@ public class OrderTransactionCaptureRefund {
    * Get stateMachineState
    * @return stateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -399,7 +387,6 @@ public class OrderTransactionCaptureRefund {
    * Get transactionCapture
    * @return transactionCapture
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSACTION_CAPTURE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -433,7 +420,6 @@ public class OrderTransactionCaptureRefund {
    * Get positions
    * @return positions
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -512,4 +498,3 @@ public class OrderTransactionCaptureRefund {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/OrderTransactionCaptureRefundPosition.java
+++ b/src/main/java/de/codebarista/shopware/model/core/OrderTransactionCaptureRefundPosition.java
@@ -111,7 +111,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -137,7 +136,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +161,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get refundId
    * @return refundId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_REFUND_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -189,7 +186,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get refundVersionId
    * @return refundVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFUND_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -215,7 +211,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get orderLineItemId
    * @return orderLineItemId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -241,7 +236,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get orderLineItemVersionId
    * @return orderLineItemVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -267,7 +261,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get externalReference
    * @return externalReference
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EXTERNAL_REFERENCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -293,7 +286,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get reason
    * @return reason
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REASON)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -319,7 +311,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get quantity
    * @return quantity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -345,7 +336,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get amount
    * @return amount
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_AMOUNT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -371,7 +361,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -391,7 +380,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -406,7 +394,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -427,7 +414,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get orderLineItem
    * @return orderLineItem
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_LINE_ITEM)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -453,7 +439,6 @@ public class OrderTransactionCaptureRefundPosition {
    * Get orderTransactionCaptureRefund
    * @return orderTransactionCaptureRefund
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_TRANSACTION_CAPTURE_REFUND)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -534,4 +519,3 @@ public class OrderTransactionCaptureRefundPosition {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Pagination.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Pagination.java
@@ -57,7 +57,6 @@ public class Pagination {
    * The first page of data
    * @return first
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class Pagination {
    * The last page of data
    * @return last
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +107,6 @@ public class Pagination {
    * The previous page of data
    * @return prev
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREV)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +132,6 @@ public class Pagination {
    * The next page of data
    * @return next
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,4 +190,3 @@ public class Pagination {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PaymentMethod.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PaymentMethod.java
@@ -144,7 +144,6 @@ public class PaymentMethod {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -170,7 +169,6 @@ public class PaymentMethod {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -190,7 +188,6 @@ public class PaymentMethod {
    * Get distinguishableName
    * @return distinguishableName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISTINGUISHABLE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -211,7 +208,6 @@ public class PaymentMethod {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -237,7 +233,6 @@ public class PaymentMethod {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -263,7 +258,6 @@ public class PaymentMethod {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -289,7 +283,6 @@ public class PaymentMethod {
    * Get afterOrderEnabled
    * @return afterOrderEnabled
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFTER_ORDER_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -315,7 +308,6 @@ public class PaymentMethod {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +333,6 @@ public class PaymentMethod {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -361,7 +352,6 @@ public class PaymentMethod {
    * Runtime field, cannot be used as part of the criteria.
    * @return synchronous
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SYNCHRONOUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -376,7 +366,6 @@ public class PaymentMethod {
    * Runtime field, cannot be used as part of the criteria.
    * @return asynchronous
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASYNCHRONOUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -391,7 +380,6 @@ public class PaymentMethod {
    * Runtime field, cannot be used as part of the criteria.
    * @return prepared
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREPARED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,7 +394,6 @@ public class PaymentMethod {
    * Runtime field, cannot be used as part of the criteria.
    * @return refundable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFUNDABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -421,7 +408,6 @@ public class PaymentMethod {
    * Runtime field, cannot be used as part of the criteria.
    * @return recurring
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RECURRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -442,7 +428,6 @@ public class PaymentMethod {
    * Runtime field, cannot be used as part of the criteria.
    * @return shortName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -468,7 +453,6 @@ public class PaymentMethod {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -488,7 +472,6 @@ public class PaymentMethod {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -503,7 +486,6 @@ public class PaymentMethod {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -524,7 +506,6 @@ public class PaymentMethod {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -550,7 +531,6 @@ public class PaymentMethod {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -641,4 +621,3 @@ public class PaymentMethod {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApi.java
@@ -161,7 +161,6 @@ public class PaymentMethodJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -187,7 +186,6 @@ public class PaymentMethodJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -221,7 +219,6 @@ public class PaymentMethodJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -247,7 +244,6 @@ public class PaymentMethodJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -281,7 +277,6 @@ public class PaymentMethodJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -315,7 +310,6 @@ public class PaymentMethodJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +335,6 @@ public class PaymentMethodJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -361,7 +354,6 @@ public class PaymentMethodJsonApi {
    * Get distinguishableName
    * @return distinguishableName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISTINGUISHABLE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -382,7 +374,6 @@ public class PaymentMethodJsonApi {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -408,7 +399,6 @@ public class PaymentMethodJsonApi {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -434,7 +424,6 @@ public class PaymentMethodJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -460,7 +449,6 @@ public class PaymentMethodJsonApi {
    * Get afterOrderEnabled
    * @return afterOrderEnabled
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFTER_ORDER_ENABLED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -486,7 +474,6 @@ public class PaymentMethodJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -512,7 +499,6 @@ public class PaymentMethodJsonApi {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -532,7 +518,6 @@ public class PaymentMethodJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return synchronous
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SYNCHRONOUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -547,7 +532,6 @@ public class PaymentMethodJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return asynchronous
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASYNCHRONOUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -562,7 +546,6 @@ public class PaymentMethodJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return prepared
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREPARED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -577,7 +560,6 @@ public class PaymentMethodJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return refundable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFUNDABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -592,7 +574,6 @@ public class PaymentMethodJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return recurring
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RECURRING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -613,7 +594,6 @@ public class PaymentMethodJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return shortName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -639,7 +619,6 @@ public class PaymentMethodJsonApi {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -659,7 +638,6 @@ public class PaymentMethodJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -674,7 +652,6 @@ public class PaymentMethodJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -695,7 +672,6 @@ public class PaymentMethodJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -794,4 +770,3 @@ public class PaymentMethodJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApiAllOfRelationships.java
@@ -45,7 +45,6 @@ public class PaymentMethodJsonApiAllOfRelationships {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class PaymentMethodJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApiAllOfRelationshipsMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApiAllOfRelationshipsMedia.java
@@ -49,7 +49,6 @@ public class PaymentMethodJsonApiAllOfRelationshipsMedia {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class PaymentMethodJsonApiAllOfRelationshipsMedia {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class PaymentMethodJsonApiAllOfRelationshipsMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApiAllOfRelationshipsMediaLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PaymentMethodJsonApiAllOfRelationshipsMediaLinks.java
@@ -45,7 +45,6 @@ public class PaymentMethodJsonApiAllOfRelationshipsMediaLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class PaymentMethodJsonApiAllOfRelationshipsMediaLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Plugin.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Plugin.java
@@ -67,7 +67,6 @@ public class Plugin {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class Plugin {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class Plugin {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class Plugin {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class Plugin {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Product.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Product.java
@@ -423,7 +423,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return id
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -450,7 +449,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return versionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -477,7 +475,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return parentId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PARENT_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -504,7 +501,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return parentVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PARENT_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -531,7 +527,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return manufacturerId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MANUFACTURER_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -558,7 +553,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return productManufacturerVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRODUCT_MANUFACTURER_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -585,7 +579,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return unitId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UNIT_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -612,7 +605,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return taxId
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_TAX_ID)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -639,7 +631,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return coverId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_COVER_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -666,7 +657,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return productMediaVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRODUCT_MEDIA_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -693,7 +683,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return deliveryTimeId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DELIVERY_TIME_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -720,7 +709,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return canonicalProductId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CANONICAL_PRODUCT_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -747,7 +735,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return cmsPageId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -774,7 +761,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return cmsPageVersionId
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -801,7 +787,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return productNumber
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_PRODUCT_NUMBER)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -828,7 +813,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return restockTime
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_RESTOCK_TIME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -855,7 +839,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return active
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ACTIVE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -876,7 +859,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return available
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_AVAILABLE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -896,7 +878,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return isCloseout
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_IS_CLOSEOUT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -917,7 +898,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return displayGroup
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DISPLAY_GROUP)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -937,7 +917,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return manufacturerNumber
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MANUFACTURER_NUMBER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -964,7 +943,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return ean
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_EAN)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -991,7 +969,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return purchaseSteps
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PURCHASE_STEPS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1018,7 +995,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return maxPurchase
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MAX_PURCHASE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1045,7 +1021,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return minPurchase
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MIN_PURCHASE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1072,7 +1047,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return purchaseUnit
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PURCHASE_UNIT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1099,7 +1073,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return referenceUnit
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_REFERENCE_UNIT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1126,7 +1099,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return shippingFree
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1153,7 +1125,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return markAsTopseller
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MARK_AS_TOPSELLER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1180,7 +1151,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return weight
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_WEIGHT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1207,7 +1177,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return width
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_WIDTH)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1234,7 +1203,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return height
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_HEIGHT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1261,7 +1229,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return length
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_LENGTH)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1288,7 +1255,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return releaseDate
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_RELEASE_DATE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1309,7 +1275,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return ratingAverage
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_RATING_AVERAGE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1323,7 +1288,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return categoryTree
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CATEGORY_TREE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1337,7 +1301,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return propertyIds
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PROPERTY_IDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1351,7 +1314,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return optionIds
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_OPTION_IDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1365,7 +1327,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return streamIds
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_STREAM_IDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1379,7 +1340,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return tagIds
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TAG_IDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1393,7 +1353,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return categoryIds
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CATEGORY_IDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1407,7 +1366,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return childCount
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CHILD_COUNT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1421,7 +1379,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return sales
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_SALES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1435,7 +1392,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return states
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_STATES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1455,7 +1411,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return metaDescription
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_META_DESCRIPTION)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1482,7 +1437,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return name
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_NAME)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1509,7 +1463,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return keywords
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_KEYWORDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1536,7 +1489,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return description
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DESCRIPTION)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1563,7 +1515,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return metaTitle
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_META_TITLE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1590,7 +1541,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return packUnit
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PACK_UNIT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1617,7 +1567,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return packUnitPlural
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PACK_UNIT_PLURAL)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1644,7 +1593,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return customFields
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1671,7 +1619,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return availableStock
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_AVAILABLE_STOCK)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1698,7 +1645,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return stock
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_STOCK)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1725,7 +1671,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return calculatedPrice
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CALCULATED_PRICE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1760,7 +1705,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return calculatedPrices
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CALCULATED_PRICES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1787,7 +1731,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return calculatedMaxPurchase
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CALCULATED_MAX_PURCHASE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1814,7 +1757,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return calculatedCheapestPrice
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CALCULATED_CHEAPEST_PRICE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1841,7 +1783,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return isNew
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_IS_NEW)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1868,7 +1809,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return sortedProperties
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_SORTED_PROPERTIES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1889,7 +1829,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return createdAt
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1903,7 +1842,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return updatedAt
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UPDATED_AT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1923,7 +1861,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return translated
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TRANSLATED)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1958,7 +1895,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return downloads
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DOWNLOADS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1985,7 +1921,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return parent
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PARENT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2020,7 +1955,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return children
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CHILDREN)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2047,7 +1981,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return deliveryTime
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_DELIVERY_TIME)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2074,7 +2007,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return tax
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TAX)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2101,7 +2033,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return manufacturer
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MANUFACTURER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2128,7 +2059,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return unit
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UNIT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2155,7 +2085,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return cover
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_COVER)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2182,7 +2111,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return cmsPage
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CMS_PAGE)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2209,7 +2137,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return canonicalProduct
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CANONICAL_PRODUCT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2244,7 +2171,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return media
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MEDIA)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2279,7 +2205,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return crossSellings
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CROSS_SELLINGS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2314,7 +2239,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return configuratorSettings
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CONFIGURATOR_SETTINGS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2349,7 +2273,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return productReviews
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PRODUCT_REVIEWS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2384,7 +2307,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return mainCategories
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_MAIN_CATEGORIES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2419,7 +2341,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return seoUrls
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_SEO_URLS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2454,7 +2375,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return options
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_OPTIONS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2489,7 +2409,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return properties
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_PROPERTIES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2524,7 +2443,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return categories
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CATEGORIES)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2559,7 +2477,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return streams
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_STREAMS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2594,7 +2511,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return categoriesRo
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CATEGORIES_RO)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2629,7 +2545,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return tags
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_TAGS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2656,7 +2571,6 @@ public class Product extends WithAdditionalProperties {
      *
      * @return seoCategory
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_SEO_CATEGORY)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2879,4 +2793,3 @@ public class Product extends WithAdditionalProperties {
     }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductConfiguratorSetting.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductConfiguratorSetting.java
@@ -99,7 +99,6 @@ public class ProductConfiguratorSetting {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +124,6 @@ public class ProductConfiguratorSetting {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +149,6 @@ public class ProductConfiguratorSetting {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -177,7 +174,6 @@ public class ProductConfiguratorSetting {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +199,6 @@ public class ProductConfiguratorSetting {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +224,6 @@ public class ProductConfiguratorSetting {
    * Get optionId
    * @return optionId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_OPTION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -255,7 +249,6 @@ public class ProductConfiguratorSetting {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -281,7 +274,6 @@ public class ProductConfiguratorSetting {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -301,7 +293,6 @@ public class ProductConfiguratorSetting {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -316,7 +307,6 @@ public class ProductConfiguratorSetting {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +327,6 @@ public class ProductConfiguratorSetting {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +352,6 @@ public class ProductConfiguratorSetting {
    * Get option
    * @return option
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_OPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -438,4 +426,3 @@ public class ProductConfiguratorSetting {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductCrossSelling.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductCrossSelling.java
@@ -95,7 +95,6 @@ public class ProductCrossSelling {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -121,7 +120,6 @@ public class ProductCrossSelling {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -147,7 +145,6 @@ public class ProductCrossSelling {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -173,7 +170,6 @@ public class ProductCrossSelling {
    * Get sortBy
    * @return sortBy
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT_BY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +195,6 @@ public class ProductCrossSelling {
    * Get sortDirection
    * @return sortDirection
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT_DIRECTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +220,6 @@ public class ProductCrossSelling {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -251,7 +245,6 @@ public class ProductCrossSelling {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -277,7 +270,6 @@ public class ProductCrossSelling {
    * Get limit
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -297,7 +289,6 @@ public class ProductCrossSelling {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -312,7 +303,6 @@ public class ProductCrossSelling {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -333,7 +323,6 @@ public class ProductCrossSelling {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,4 +395,3 @@ public class ProductCrossSelling {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductCrossSellingAssignedProducts.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductCrossSellingAssignedProducts.java
@@ -63,7 +63,6 @@ public class ProductCrossSellingAssignedProducts {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductCrossSellingAssignedProducts {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductCrossSellingAssignedProducts {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductCrossSellingAssignedProducts {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductDetailResponse.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductDetailResponse.java
@@ -49,7 +49,6 @@ public class ProductDetailResponse {
    * Get product
    * @return product
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductDetailResponse {
    * List of property groups with their corresponding options and information on how to display them.
    * @return configurator
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONFIGURATOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -138,4 +136,3 @@ public class ProductDetailResponse {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductDownload.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductDownload.java
@@ -95,7 +95,6 @@ public class ProductDownload {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -121,7 +120,6 @@ public class ProductDownload {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +145,6 @@ public class ProductDownload {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -173,7 +170,6 @@ public class ProductDownload {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +195,6 @@ public class ProductDownload {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -225,7 +220,6 @@ public class ProductDownload {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +245,6 @@ public class ProductDownload {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -271,7 +264,6 @@ public class ProductDownload {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -286,7 +278,6 @@ public class ProductDownload {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -307,7 +298,6 @@ public class ProductDownload {
    * Get product
    * @return product
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -333,7 +323,6 @@ public class ProductDownload {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,4 +395,3 @@ public class ProductDownload {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductExport.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductExport.java
@@ -63,7 +63,6 @@ public class ProductExport {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductExport {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductExport {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductExport {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductFeatureSet.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductFeatureSet.java
@@ -67,7 +67,6 @@ public class ProductFeatureSet {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class ProductFeatureSet {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class ProductFeatureSet {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class ProductFeatureSet {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class ProductFeatureSet {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApi.java
@@ -351,7 +351,6 @@ public class ProductJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -377,7 +376,6 @@ public class ProductJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -411,7 +409,6 @@ public class ProductJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -437,7 +434,6 @@ public class ProductJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -471,7 +467,6 @@ public class ProductJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -505,7 +500,6 @@ public class ProductJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -531,7 +525,6 @@ public class ProductJsonApi {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -557,7 +550,6 @@ public class ProductJsonApi {
    * Get parentId
    * @return parentId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -583,7 +575,6 @@ public class ProductJsonApi {
    * Get parentVersionId
    * @return parentVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -609,7 +600,6 @@ public class ProductJsonApi {
    * Get manufacturerId
    * @return manufacturerId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -635,7 +625,6 @@ public class ProductJsonApi {
    * Get productManufacturerVersionId
    * @return productManufacturerVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_MANUFACTURER_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -661,7 +650,6 @@ public class ProductJsonApi {
    * Get unitId
    * @return unitId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UNIT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -687,7 +675,6 @@ public class ProductJsonApi {
    * Get taxId
    * @return taxId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAX_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -713,7 +700,6 @@ public class ProductJsonApi {
    * Get coverId
    * @return coverId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COVER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -739,7 +725,6 @@ public class ProductJsonApi {
    * Get productMediaVersionId
    * @return productMediaVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_MEDIA_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -765,7 +750,6 @@ public class ProductJsonApi {
    * Get deliveryTimeId
    * @return deliveryTimeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -791,7 +775,6 @@ public class ProductJsonApi {
    * Get canonicalProductId
    * @return canonicalProductId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CANONICAL_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -817,7 +800,6 @@ public class ProductJsonApi {
    * Get cmsPageId
    * @return cmsPageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -843,7 +825,6 @@ public class ProductJsonApi {
    * Get cmsPageVersionId
    * @return cmsPageVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -869,7 +850,6 @@ public class ProductJsonApi {
    * Get productNumber
    * @return productNumber
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_NUMBER)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -895,7 +875,6 @@ public class ProductJsonApi {
    * Get restockTime
    * @return restockTime
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RESTOCK_TIME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -921,7 +900,6 @@ public class ProductJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -941,7 +919,6 @@ public class ProductJsonApi {
    * Get available
    * @return available
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -962,7 +939,6 @@ public class ProductJsonApi {
    * Get isCloseout
    * @return isCloseout
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_CLOSEOUT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -982,7 +958,6 @@ public class ProductJsonApi {
    * Get displayGroup
    * @return displayGroup
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISPLAY_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1003,7 +978,6 @@ public class ProductJsonApi {
    * Get manufacturerNumber
    * @return manufacturerNumber
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1029,7 +1003,6 @@ public class ProductJsonApi {
    * Get ean
    * @return ean
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EAN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1055,7 +1028,6 @@ public class ProductJsonApi {
    * Get purchaseSteps
    * @return purchaseSteps
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PURCHASE_STEPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1081,7 +1053,6 @@ public class ProductJsonApi {
    * Get maxPurchase
    * @return maxPurchase
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PURCHASE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1107,7 +1078,6 @@ public class ProductJsonApi {
    * Get minPurchase
    * @return minPurchase
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PURCHASE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1133,7 +1103,6 @@ public class ProductJsonApi {
    * Get purchaseUnit
    * @return purchaseUnit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PURCHASE_UNIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1159,7 +1128,6 @@ public class ProductJsonApi {
    * Get referenceUnit
    * @return referenceUnit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REFERENCE_UNIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1185,7 +1153,6 @@ public class ProductJsonApi {
    * Get shippingFree
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1211,7 +1178,6 @@ public class ProductJsonApi {
    * Get markAsTopseller
    * @return markAsTopseller
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MARK_AS_TOPSELLER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1237,7 +1203,6 @@ public class ProductJsonApi {
    * Get weight
    * @return weight
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_WEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1263,7 +1228,6 @@ public class ProductJsonApi {
    * Get width
    * @return width
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_WIDTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1289,7 +1253,6 @@ public class ProductJsonApi {
    * Get height
    * @return height
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HEIGHT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1315,7 +1278,6 @@ public class ProductJsonApi {
    * Get length
    * @return length
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LENGTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1341,7 +1303,6 @@ public class ProductJsonApi {
    * Get releaseDate
    * @return releaseDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELEASE_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1361,7 +1322,6 @@ public class ProductJsonApi {
    * Get ratingAverage
    * @return ratingAverage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_AVERAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1376,7 +1336,6 @@ public class ProductJsonApi {
    * Get categoryTree
    * @return categoryTree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CATEGORY_TREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1391,7 +1350,6 @@ public class ProductJsonApi {
    * Get propertyIds
    * @return propertyIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1406,7 +1364,6 @@ public class ProductJsonApi {
    * Get optionIds
    * @return optionIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_OPTION_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1421,7 +1378,6 @@ public class ProductJsonApi {
    * Get streamIds
    * @return streamIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STREAM_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1436,7 +1392,6 @@ public class ProductJsonApi {
    * Get tagIds
    * @return tagIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAG_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1451,7 +1406,6 @@ public class ProductJsonApi {
    * Get categoryIds
    * @return categoryIds
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CATEGORY_IDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1466,7 +1420,6 @@ public class ProductJsonApi {
    * Get childCount
    * @return childCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILD_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1481,7 +1434,6 @@ public class ProductJsonApi {
    * Get sales
    * @return sales
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1496,7 +1448,6 @@ public class ProductJsonApi {
    * Get states
    * @return states
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1517,7 +1468,6 @@ public class ProductJsonApi {
    * Get metaDescription
    * @return metaDescription
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1543,7 +1493,6 @@ public class ProductJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1569,7 +1518,6 @@ public class ProductJsonApi {
    * Get keywords
    * @return keywords
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_KEYWORDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1595,7 +1543,6 @@ public class ProductJsonApi {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1621,7 +1568,6 @@ public class ProductJsonApi {
    * Get metaTitle
    * @return metaTitle
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1647,7 +1593,6 @@ public class ProductJsonApi {
    * Get packUnit
    * @return packUnit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PACK_UNIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1673,7 +1618,6 @@ public class ProductJsonApi {
    * Get packUnitPlural
    * @return packUnitPlural
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PACK_UNIT_PLURAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1699,7 +1643,6 @@ public class ProductJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1725,7 +1668,6 @@ public class ProductJsonApi {
    * Get availableStock
    * @return availableStock
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABLE_STOCK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1751,7 +1693,6 @@ public class ProductJsonApi {
    * Get stock
    * @return stock
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STOCK)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1777,7 +1718,6 @@ public class ProductJsonApi {
    * Get calculatedPrice
    * @return calculatedPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATED_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1811,7 +1751,6 @@ public class ProductJsonApi {
    * Get calculatedPrices
    * @return calculatedPrices
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATED_PRICES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1837,7 +1776,6 @@ public class ProductJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return calculatedMaxPurchase
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATED_MAX_PURCHASE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1863,7 +1801,6 @@ public class ProductJsonApi {
    * Get calculatedCheapestPrice
    * @return calculatedCheapestPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATED_CHEAPEST_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1889,7 +1826,6 @@ public class ProductJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return isNew
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_NEW)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1915,7 +1851,6 @@ public class ProductJsonApi {
    * Get sortedProperties
    * @return sortedProperties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORTED_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1935,7 +1870,6 @@ public class ProductJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1950,7 +1884,6 @@ public class ProductJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1971,7 +1904,6 @@ public class ProductJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -2158,4 +2090,3 @@ public class ProductJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationships.java
@@ -133,7 +133,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get downloads
    * @return downloads
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOWNLOADS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -159,7 +158,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get parent
    * @return parent
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -185,7 +183,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get children
    * @return children
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHILDREN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -211,7 +208,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get deliveryTime
    * @return deliveryTime
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -237,7 +233,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get tax
    * @return tax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -263,7 +258,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get manufacturer
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -289,7 +283,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get unit
    * @return unit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UNIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -315,7 +308,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get cover
    * @return cover
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COVER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +333,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get cmsPage
    * @return cmsPage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -367,7 +358,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get canonicalProduct
    * @return canonicalProduct
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CANONICAL_PRODUCT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -393,7 +383,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -419,7 +408,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get crossSellings
    * @return crossSellings
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CROSS_SELLINGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -445,7 +433,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get configuratorSettings
    * @return configuratorSettings
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONFIGURATOR_SETTINGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -471,7 +458,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get productReviews
    * @return productReviews
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_REVIEWS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -497,7 +483,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get mainCategories
    * @return mainCategories
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAIN_CATEGORIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -523,7 +508,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get seoUrls
    * @return seoUrls
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SEO_URLS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -549,7 +533,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get options
    * @return options
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -575,7 +558,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get properties
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -601,7 +583,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get categories
    * @return categories
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CATEGORIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -627,7 +608,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get streams
    * @return streams
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STREAMS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -653,7 +633,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get categoriesRo
    * @return categoriesRo
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CATEGORIES_RO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -679,7 +658,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -705,7 +683,6 @@ public class ProductJsonApiAllOfRelationships {
    * Get seoCategory
    * @return seoCategory
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SEO_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -802,4 +779,3 @@ public class ProductJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCanonicalProduct.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCanonicalProduct.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProduct {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProduct {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProduct {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCanonicalProductData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCanonicalProductData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProductData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProductData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProductData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCanonicalProductLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCanonicalProductLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProductLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsCanonicalProductLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategories.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategories.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsCategories {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsCategories {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsCategories {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCategoriesData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsCategoriesLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesRo.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesRo.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRo {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRo {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRo {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesRoData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesRoData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRoData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRoData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRoData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesRoLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCategoriesRoLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRoLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsCategoriesRoLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsChildren.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsChildren.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsChildren {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsChildren {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsChildren {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsChildrenData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsChildrenData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsChildrenData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsChildrenData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsChildrenData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsChildrenLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsChildrenLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsChildrenLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsChildrenLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCmsPage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCmsPage.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCmsPage {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCmsPage {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCmsPage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCmsPageLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCmsPageLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsCmsPageLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsCmsPageLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsConfiguratorSettings.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsConfiguratorSettings.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettings {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettings {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettings {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsConfiguratorSettingsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsConfiguratorSettingsData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettingsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettingsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettingsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsConfiguratorSettingsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsConfiguratorSettingsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettingsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsConfiguratorSettingsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCover.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCover.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCover {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCover {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCover {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCoverData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCoverData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCoverData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCoverData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCoverData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCoverLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCoverLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsCoverLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsCoverLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCrossSellings.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCrossSellings.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsCrossSellings {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsCrossSellings {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsCrossSellings {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCrossSellingsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCrossSellingsData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsCrossSellingsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsCrossSellingsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsCrossSellingsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCrossSellingsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsCrossSellingsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsCrossSellingsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsCrossSellingsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDeliveryTime.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDeliveryTime.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTime {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTime {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTime {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDeliveryTimeData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDeliveryTimeData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTimeData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTimeData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTimeData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDeliveryTimeLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDeliveryTimeLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTimeLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsDeliveryTimeLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDownloads.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDownloads.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsDownloads {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsDownloads {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsDownloads {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDownloadsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDownloadsData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsDownloadsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsDownloadsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsDownloadsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDownloadsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsDownloadsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsDownloadsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsDownloadsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMainCategories.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMainCategories.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsMainCategories {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsMainCategories {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsMainCategories {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMainCategoriesData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMainCategoriesData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsMainCategoriesData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsMainCategoriesData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsMainCategoriesData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMainCategoriesLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMainCategoriesLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsMainCategoriesLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsMainCategoriesLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsManufacturer.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsManufacturer.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsManufacturer {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsManufacturer {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsManufacturer {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsManufacturerData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsManufacturerData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsManufacturerData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsManufacturerData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsManufacturerData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsManufacturerLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsManufacturerLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsManufacturerLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsManufacturerLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMedia.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsMedia {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsMedia {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMediaData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMediaData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsMediaData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsMediaData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsMediaData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMediaLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsMediaLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsMediaLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsMediaLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsOptions.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsOptions.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsOptions {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsOptions {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsOptions {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsOptionsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsOptionsData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsOptionsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsOptionsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsOptionsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsOptionsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsOptionsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsOptionsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsOptionsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsParent.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsParent.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsParent {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsParent {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsParent {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsParentData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsParentData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsParentData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsParentData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsParentData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsParentLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsParentLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsParentLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsParentLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProductReviews.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProductReviews.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsProductReviews {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsProductReviews {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsProductReviews {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProductReviewsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProductReviewsData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsProductReviewsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsProductReviewsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsProductReviewsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProductReviewsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProductReviewsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsProductReviewsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsProductReviewsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProperties.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsProperties.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsProperties {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsProperties {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsProperties {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsPropertiesData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsPropertiesData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsPropertiesData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsPropertiesData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsPropertiesData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsPropertiesLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsPropertiesLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsPropertiesLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsPropertiesLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoCategory.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoCategory.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsSeoCategory {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsSeoCategory {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsSeoCategory {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoCategoryData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoCategoryData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsSeoCategoryData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsSeoCategoryData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsSeoCategoryData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoCategoryLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoCategoryLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsSeoCategoryLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsSeoCategoryLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoUrls.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoUrls.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsSeoUrls {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsSeoUrls {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsSeoUrls {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoUrlsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsSeoUrlsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsSeoUrlsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsSeoUrlsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsStreams.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsStreams.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsStreams {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsStreams {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsStreams {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsStreamsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsStreamsData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsStreamsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsStreamsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsStreamsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsStreamsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsStreamsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsStreamsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsStreamsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTags.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTags.java
@@ -51,7 +51,6 @@ public class ProductJsonApiAllOfRelationshipsTags {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ProductJsonApiAllOfRelationshipsTags {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ProductJsonApiAllOfRelationshipsTags {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTagsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTagsLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsTagsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsTagsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTax.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTax.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsTax {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsTax {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsTax {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTaxData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTaxData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsTaxData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsTaxData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsTaxData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTaxLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsTaxLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsTaxLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsTaxLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsUnit.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsUnit.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsUnit {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsUnit {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsUnit {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsUnitData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsUnitData.java
@@ -49,7 +49,6 @@ public class ProductJsonApiAllOfRelationshipsUnitData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductJsonApiAllOfRelationshipsUnitData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductJsonApiAllOfRelationshipsUnitData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsUnitLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductJsonApiAllOfRelationshipsUnitLinks.java
@@ -45,7 +45,6 @@ public class ProductJsonApiAllOfRelationshipsUnitLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ProductJsonApiAllOfRelationshipsUnitLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductKeywordDictionary.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductKeywordDictionary.java
@@ -51,7 +51,6 @@ public class ProductKeywordDictionary {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -77,7 +76,6 @@ public class ProductKeywordDictionary {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -103,7 +101,6 @@ public class ProductKeywordDictionary {
    * Get keyword
    * @return keyword
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_KEYWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -160,4 +157,3 @@ public class ProductKeywordDictionary {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductListingCriteria.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductListingCriteria.java
@@ -183,7 +183,6 @@ public class ProductListingCriteria {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -210,7 +209,6 @@ public class ProductListingCriteria {
    * minimum: 0
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -244,7 +242,6 @@ public class ProductListingCriteria {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,7 +275,6 @@ public class ProductListingCriteria {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -312,7 +308,6 @@ public class ProductListingCriteria {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -338,7 +333,6 @@ public class ProductListingCriteria {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -372,7 +366,6 @@ public class ProductListingCriteria {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,7 +399,6 @@ public class ProductListingCriteria {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -440,7 +432,6 @@ public class ProductListingCriteria {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -466,7 +457,6 @@ public class ProductListingCriteria {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -492,7 +482,6 @@ public class ProductListingCriteria {
    * Specifies the sorting of the products by &#x60;availableSortings&#x60;. If not set, the default sorting will be set according to the shop settings. The available sorting options are sent within the response under the &#x60;availableSortings&#x60; key. In order to sort by a field, consider using the &#x60;sort&#x60; parameter from the listing criteria. Do not use both parameters together, as it might lead to unexpected results.
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -518,7 +507,6 @@ public class ProductListingCriteria {
    * Search result page
    * @return p
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_P)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -544,7 +532,6 @@ public class ProductListingCriteria {
    * Filter by manufacturers. List of manufacturer identifiers separated by a &#x60;|&#x60;.
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -571,7 +558,6 @@ public class ProductListingCriteria {
    * minimum: 0
    * @return minPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -598,7 +584,6 @@ public class ProductListingCriteria {
    * minimum: 0
    * @return maxPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -624,7 +609,6 @@ public class ProductListingCriteria {
    * Filter products with a minimum average rating.
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -650,7 +634,6 @@ public class ProductListingCriteria {
    * Filters products that are marked as shipping-free.
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -676,7 +659,6 @@ public class ProductListingCriteria {
    * Filters products by their properties. List of property identifiers separated by a &#x60;|&#x60;.
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -702,7 +684,6 @@ public class ProductListingCriteria {
    * Enables/disabled filtering by manufacturer. If set to false, the &#x60;manufacturer&#x60; filter will be ignored. Also the &#x60;aggregations[manufacturer]&#x60; key will be removed from the response.
    * @return manufacturerFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -728,7 +709,6 @@ public class ProductListingCriteria {
    * Enables/disabled filtering by price. If set to false, the &#x60;min-price&#x60; and &#x60;max-price&#x60; filter will be ignored. Also the &#x60;aggregations[price]&#x60; key will be removed from the response.
    * @return priceFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -754,7 +734,6 @@ public class ProductListingCriteria {
    * Enables/disabled filtering by rating. If set to false, the &#x60;rating&#x60; filter will be ignored. Also the &#x60;aggregations[rating]&#x60; key will be removed from the response.
    * @return ratingFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -780,7 +759,6 @@ public class ProductListingCriteria {
    * Enables/disabled filtering by shipping-free products. If set to false, the &#x60;shipping-free&#x60; filter will be ignored. Also the &#x60;aggregations[shipping-free]&#x60; key will be removed from the response.
    * @return shippingFreeFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -806,7 +784,6 @@ public class ProductListingCriteria {
    * Enables/disabled filtering by properties products. If set to false, the &#x60;properties&#x60; filter will be ignored. Also the &#x60;aggregations[properties]&#x60; key will be removed from the response.
    * @return propertyFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -832,7 +809,6 @@ public class ProductListingCriteria {
    * A whitelist of property identifiers which can be used for filtering. List of property identifiers separated by a &#x60;|&#x60;. The &#x60;property-filter&#x60; must be &#x60;true&#x60;, otherwise the whitelist has no effect.
    * @return propertyWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -858,7 +834,6 @@ public class ProductListingCriteria {
    * By sending the parameter &#x60;reduce-aggregations&#x60; , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.
    * @return reduceAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getReduceAggregations() {
@@ -978,4 +953,3 @@ public class ProductListingCriteria {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductListingFlags.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductListingFlags.java
@@ -50,7 +50,6 @@ public class ProductListingFlags {
    * Resets all aggregations in the criteria. This parameter is a flag, the value has no effect.
    * @return noAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getNoAggregations() {
@@ -84,7 +83,6 @@ public class ProductListingFlags {
    * If this flag is set, no products are fetched. Sorting and associations are also ignored. This parameter is a flag, the value has no effect.
    * @return onlyAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getOnlyAggregations() {
@@ -158,4 +156,3 @@ public class ProductListingFlags {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductListingResult.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductListingResult.java
@@ -81,7 +81,6 @@ public class ProductListingResult {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -107,7 +106,6 @@ public class ProductListingResult {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -133,7 +131,6 @@ public class ProductListingResult {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -167,7 +164,6 @@ public class ProductListingResult {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -193,7 +189,6 @@ public class ProductListingResult {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -219,7 +214,6 @@ public class ProductListingResult {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -245,7 +239,6 @@ public class ProductListingResult {
    * Get currentFilters
    * @return currentFilters
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENT_FILTERS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -279,7 +272,6 @@ public class ProductListingResult {
    * Contains the available sorting. These can be used to show a sorting select-box in the product listing.
    * @return availableSortings
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABLE_SORTINGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -305,7 +297,6 @@ public class ProductListingResult {
    * Get sorting
    * @return sorting
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORTING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -339,7 +330,6 @@ public class ProductListingResult {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -410,4 +400,3 @@ public class ProductListingResult {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductListingResultAllOfCurrentFilters.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductListingResultAllOfCurrentFilters.java
@@ -67,7 +67,6 @@ public class ProductListingResultAllOfCurrentFilters {
    * Get navigationId
    * @return navigationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class ProductListingResultAllOfCurrentFilters {
    * Get manufacturer
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -127,7 +125,6 @@ public class ProductListingResultAllOfCurrentFilters {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +150,6 @@ public class ProductListingResultAllOfCurrentFilters {
    * Get rating
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -179,7 +175,6 @@ public class ProductListingResultAllOfCurrentFilters {
    * Get shippingFree
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +208,6 @@ public class ProductListingResultAllOfCurrentFilters {
    * Get properties
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -276,4 +270,3 @@ public class ProductListingResultAllOfCurrentFilters {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductListingResultAllOfCurrentFiltersPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductListingResultAllOfCurrentFiltersPrice.java
@@ -49,7 +49,6 @@ public class ProductListingResultAllOfCurrentFiltersPrice {
    * Get min
    * @return min
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ProductListingResultAllOfCurrentFiltersPrice {
    * Get max
    * @return max
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ProductListingResultAllOfCurrentFiltersPrice {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductManufacturer.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductManufacturer.java
@@ -95,7 +95,6 @@ public class ProductManufacturer {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -121,7 +120,6 @@ public class ProductManufacturer {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +145,6 @@ public class ProductManufacturer {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +170,6 @@ public class ProductManufacturer {
    * Get link
    * @return link
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINK)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +195,6 @@ public class ProductManufacturer {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -225,7 +220,6 @@ public class ProductManufacturer {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +245,6 @@ public class ProductManufacturer {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -271,7 +264,6 @@ public class ProductManufacturer {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -286,7 +278,6 @@ public class ProductManufacturer {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -307,7 +298,6 @@ public class ProductManufacturer {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -333,7 +323,6 @@ public class ProductManufacturer {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,4 +395,3 @@ public class ProductManufacturer {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductMedia.java
@@ -91,7 +91,6 @@ public class ProductMedia {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +116,6 @@ public class ProductMedia {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -143,7 +141,6 @@ public class ProductMedia {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -169,7 +166,6 @@ public class ProductMedia {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -195,7 +191,6 @@ public class ProductMedia {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -221,7 +216,6 @@ public class ProductMedia {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -247,7 +241,6 @@ public class ProductMedia {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -267,7 +260,6 @@ public class ProductMedia {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -282,7 +274,6 @@ public class ProductMedia {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +294,6 @@ public class ProductMedia {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -374,4 +364,3 @@ public class ProductMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductPrice.java
@@ -63,7 +63,6 @@ public class ProductPrice {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductPrice {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductPrice {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductPrice {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductReview.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductReview.java
@@ -103,7 +103,6 @@ public class ProductReview {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -129,7 +128,6 @@ public class ProductReview {
    * Get productId
    * @return productId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRODUCT_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -155,7 +153,6 @@ public class ProductReview {
    * Get productVersionId
    * @return productVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCT_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -181,7 +178,6 @@ public class ProductReview {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -207,7 +203,6 @@ public class ProductReview {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -233,7 +228,6 @@ public class ProductReview {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -259,7 +253,6 @@ public class ProductReview {
    * Get content
    * @return content
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CONTENT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -285,7 +278,6 @@ public class ProductReview {
    * Get points
    * @return points
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POINTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -311,7 +303,6 @@ public class ProductReview {
    * Get status
    * @return status
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATUS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +328,6 @@ public class ProductReview {
    * Get comment
    * @return comment
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +353,6 @@ public class ProductReview {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -383,7 +372,6 @@ public class ProductReview {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -398,7 +386,6 @@ public class ProductReview {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -470,4 +457,3 @@ public class ProductReview {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductSearchConfig.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductSearchConfig.java
@@ -63,7 +63,6 @@ public class ProductSearchConfig {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductSearchConfig {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductSearchConfig {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductSearchConfig {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductSearchConfigField.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductSearchConfigField.java
@@ -63,7 +63,6 @@ public class ProductSearchConfigField {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductSearchConfigField {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductSearchConfigField {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductSearchConfigField {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductSearchKeyword.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductSearchKeyword.java
@@ -63,7 +63,6 @@ public class ProductSearchKeyword {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductSearchKeyword {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductSearchKeyword {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductSearchKeyword {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductSorting.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductSorting.java
@@ -79,7 +79,6 @@ public class ProductSorting {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class ProductSorting {
    * Get key
    * @return key
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class ProductSorting {
    * Get priority
    * @return priority
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRIORITY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +154,6 @@ public class ProductSorting {
    * Get label
    * @return label
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LABEL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -177,7 +173,6 @@ public class ProductSorting {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,7 +187,6 @@ public class ProductSorting {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +207,6 @@ public class ProductSorting {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class ProductSorting {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductStream.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductStream.java
@@ -79,7 +79,6 @@ public class ProductStream {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class ProductStream {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class ProductStream {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ProductStream {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class ProductStream {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,7 +187,6 @@ public class ProductStream {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +207,6 @@ public class ProductStream {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class ProductStream {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductStreamFilter.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductStreamFilter.java
@@ -63,7 +63,6 @@ public class ProductStreamFilter {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductStreamFilter {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductStreamFilter {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductStreamFilter {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ProductVisibility.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ProductVisibility.java
@@ -63,7 +63,6 @@ public class ProductVisibility {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ProductVisibility {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ProductVisibility {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ProductVisibility {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Promotion.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Promotion.java
@@ -71,7 +71,6 @@ public class Promotion {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class Promotion {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +115,6 @@ public class Promotion {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -132,7 +129,6 @@ public class Promotion {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +149,6 @@ public class Promotion {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -214,4 +209,3 @@ public class Promotion {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PromotionDiscount.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PromotionDiscount.java
@@ -63,7 +63,6 @@ public class PromotionDiscount {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class PromotionDiscount {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class PromotionDiscount {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class PromotionDiscount {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PromotionDiscountPrices.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PromotionDiscountPrices.java
@@ -63,7 +63,6 @@ public class PromotionDiscountPrices {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class PromotionDiscountPrices {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class PromotionDiscountPrices {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class PromotionDiscountPrices {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PromotionIndividualCode.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PromotionIndividualCode.java
@@ -63,7 +63,6 @@ public class PromotionIndividualCode {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class PromotionIndividualCode {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class PromotionIndividualCode {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class PromotionIndividualCode {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PromotionSalesChannel.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PromotionSalesChannel.java
@@ -63,7 +63,6 @@ public class PromotionSalesChannel {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class PromotionSalesChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class PromotionSalesChannel {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class PromotionSalesChannel {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PromotionSetgroup.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PromotionSetgroup.java
@@ -63,7 +63,6 @@ public class PromotionSetgroup {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class PromotionSetgroup {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class PromotionSetgroup {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class PromotionSetgroup {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PropertyGroup.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PropertyGroup.java
@@ -105,7 +105,6 @@ public class PropertyGroup {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -131,7 +130,6 @@ public class PropertyGroup {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +155,6 @@ public class PropertyGroup {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +180,6 @@ public class PropertyGroup {
    * Get displayType
    * @return displayType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DISPLAY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -209,7 +205,6 @@ public class PropertyGroup {
    * Get sortingType
    * @return sortingType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SORTING_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -235,7 +230,6 @@ public class PropertyGroup {
    * Get filterable
    * @return filterable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTERABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -261,7 +255,6 @@ public class PropertyGroup {
    * Get visibleOnProductDetailPage
    * @return visibleOnProductDetailPage
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VISIBLE_ON_PRODUCT_DETAIL_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -287,7 +280,6 @@ public class PropertyGroup {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -313,7 +305,6 @@ public class PropertyGroup {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -333,7 +324,6 @@ public class PropertyGroup {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -348,7 +338,6 @@ public class PropertyGroup {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -369,7 +358,6 @@ public class PropertyGroup {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -403,7 +391,6 @@ public class PropertyGroup {
    * Get options
    * @return options
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -480,4 +467,3 @@ public class PropertyGroup {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/PropertyGroupOption.java
+++ b/src/main/java/de/codebarista/shopware/model/core/PropertyGroupOption.java
@@ -99,7 +99,6 @@ public class PropertyGroupOption {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +124,6 @@ public class PropertyGroupOption {
    * Get groupId
    * @return groupId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_GROUP_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -151,7 +149,6 @@ public class PropertyGroupOption {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -177,7 +174,6 @@ public class PropertyGroupOption {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +199,6 @@ public class PropertyGroupOption {
    * Get colorHexCode
    * @return colorHexCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COLOR_HEX_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +224,6 @@ public class PropertyGroupOption {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +249,6 @@ public class PropertyGroupOption {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -275,7 +268,6 @@ public class PropertyGroupOption {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -290,7 +282,6 @@ public class PropertyGroupOption {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -311,7 +302,6 @@ public class PropertyGroupOption {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -337,7 +327,6 @@ public class PropertyGroupOption {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -363,7 +352,6 @@ public class PropertyGroupOption {
    * Get group
    * @return group
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -438,4 +426,3 @@ public class PropertyGroupOption {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadCategoryList200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadCategoryList200Response.java
@@ -71,7 +71,6 @@ public class ReadCategoryList200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadCategoryList200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadCategoryList200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadCategoryList200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadCategoryList200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadCategoryList200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadCategoryList200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadCategoryList200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadCategoryRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadCategoryRequest.java
@@ -185,7 +185,6 @@ public class ReadCategoryRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -212,7 +211,6 @@ public class ReadCategoryRequest {
    * minimum: 0
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -246,7 +244,6 @@ public class ReadCategoryRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -280,7 +277,6 @@ public class ReadCategoryRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -314,7 +310,6 @@ public class ReadCategoryRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -340,7 +335,6 @@ public class ReadCategoryRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -374,7 +368,6 @@ public class ReadCategoryRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -408,7 +401,6 @@ public class ReadCategoryRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -442,7 +434,6 @@ public class ReadCategoryRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -468,7 +459,6 @@ public class ReadCategoryRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -494,7 +484,6 @@ public class ReadCategoryRequest {
    * Specifies the sorting of the products by &#x60;availableSortings&#x60;. If not set, the default sorting will be set according to the shop settings. The available sorting options are sent within the response under the &#x60;availableSortings&#x60; key. In order to sort by a field, consider using the &#x60;sort&#x60; parameter from the listing criteria. Do not use both parameters together, as it might lead to unexpected results.
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -520,7 +509,6 @@ public class ReadCategoryRequest {
    * Search result page
    * @return p
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_P)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -546,7 +534,6 @@ public class ReadCategoryRequest {
    * Filter by manufacturers. List of manufacturer identifiers separated by a &#x60;|&#x60;.
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -573,7 +560,6 @@ public class ReadCategoryRequest {
    * minimum: 0
    * @return minPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -600,7 +586,6 @@ public class ReadCategoryRequest {
    * minimum: 0
    * @return maxPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -626,7 +611,6 @@ public class ReadCategoryRequest {
    * Filter products with a minimum average rating.
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -652,7 +636,6 @@ public class ReadCategoryRequest {
    * Filters products that are marked as shipping-free.
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -678,7 +661,6 @@ public class ReadCategoryRequest {
    * Filters products by their properties. List of property identifiers separated by a &#x60;|&#x60;.
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -704,7 +686,6 @@ public class ReadCategoryRequest {
    * Enables/disabled filtering by manufacturer. If set to false, the &#x60;manufacturer&#x60; filter will be ignored. Also the &#x60;aggregations[manufacturer]&#x60; key will be removed from the response.
    * @return manufacturerFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -730,7 +711,6 @@ public class ReadCategoryRequest {
    * Enables/disabled filtering by price. If set to false, the &#x60;min-price&#x60; and &#x60;max-price&#x60; filter will be ignored. Also the &#x60;aggregations[price]&#x60; key will be removed from the response.
    * @return priceFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -756,7 +736,6 @@ public class ReadCategoryRequest {
    * Enables/disabled filtering by rating. If set to false, the &#x60;rating&#x60; filter will be ignored. Also the &#x60;aggregations[rating]&#x60; key will be removed from the response.
    * @return ratingFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -782,7 +761,6 @@ public class ReadCategoryRequest {
    * Enables/disabled filtering by shipping-free products. If set to false, the &#x60;shipping-free&#x60; filter will be ignored. Also the &#x60;aggregations[shipping-free]&#x60; key will be removed from the response.
    * @return shippingFreeFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -808,7 +786,6 @@ public class ReadCategoryRequest {
    * Enables/disabled filtering by properties products. If set to false, the &#x60;properties&#x60; filter will be ignored. Also the &#x60;aggregations[properties]&#x60; key will be removed from the response.
    * @return propertyFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -834,7 +811,6 @@ public class ReadCategoryRequest {
    * A whitelist of property identifiers which can be used for filtering. List of property identifiers separated by a &#x60;|&#x60;. The &#x60;property-filter&#x60; must be &#x60;true&#x60;, otherwise the whitelist has no effect.
    * @return propertyWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -860,7 +836,6 @@ public class ReadCategoryRequest {
    * By sending the parameter &#x60;reduce-aggregations&#x60; , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.
    * @return reduceAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getReduceAggregations() {
@@ -980,4 +955,3 @@ public class ReadCategoryRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadCmsRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadCmsRequest.java
@@ -189,7 +189,6 @@ public class ReadCmsRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -216,7 +215,6 @@ public class ReadCmsRequest {
    * minimum: 0
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -250,7 +248,6 @@ public class ReadCmsRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -284,7 +281,6 @@ public class ReadCmsRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -318,7 +314,6 @@ public class ReadCmsRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -344,7 +339,6 @@ public class ReadCmsRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -378,7 +372,6 @@ public class ReadCmsRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -412,7 +405,6 @@ public class ReadCmsRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -446,7 +438,6 @@ public class ReadCmsRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -472,7 +463,6 @@ public class ReadCmsRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -498,7 +488,6 @@ public class ReadCmsRequest {
    * Specifies the sorting of the products by &#x60;availableSortings&#x60;. If not set, the default sorting will be set according to the shop settings. The available sorting options are sent within the response under the &#x60;availableSortings&#x60; key. In order to sort by a field, consider using the &#x60;sort&#x60; parameter from the listing criteria. Do not use both parameters together, as it might lead to unexpected results.
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -524,7 +513,6 @@ public class ReadCmsRequest {
    * Search result page
    * @return p
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_P)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -550,7 +538,6 @@ public class ReadCmsRequest {
    * Filter by manufacturers. List of manufacturer identifiers separated by a &#x60;|&#x60;.
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -577,7 +564,6 @@ public class ReadCmsRequest {
    * minimum: 0
    * @return minPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -604,7 +590,6 @@ public class ReadCmsRequest {
    * minimum: 0
    * @return maxPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -630,7 +615,6 @@ public class ReadCmsRequest {
    * Filter products with a minimum average rating.
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -656,7 +640,6 @@ public class ReadCmsRequest {
    * Filters products that are marked as shipping-free.
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -682,7 +665,6 @@ public class ReadCmsRequest {
    * Filters products by their properties. List of property identifiers separated by a &#x60;|&#x60;.
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -708,7 +690,6 @@ public class ReadCmsRequest {
    * Enables/disabled filtering by manufacturer. If set to false, the &#x60;manufacturer&#x60; filter will be ignored. Also the &#x60;aggregations[manufacturer]&#x60; key will be removed from the response.
    * @return manufacturerFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -734,7 +715,6 @@ public class ReadCmsRequest {
    * Enables/disabled filtering by price. If set to false, the &#x60;min-price&#x60; and &#x60;max-price&#x60; filter will be ignored. Also the &#x60;aggregations[price]&#x60; key will be removed from the response.
    * @return priceFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -760,7 +740,6 @@ public class ReadCmsRequest {
    * Enables/disabled filtering by rating. If set to false, the &#x60;rating&#x60; filter will be ignored. Also the &#x60;aggregations[rating]&#x60; key will be removed from the response.
    * @return ratingFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -786,7 +765,6 @@ public class ReadCmsRequest {
    * Enables/disabled filtering by shipping-free products. If set to false, the &#x60;shipping-free&#x60; filter will be ignored. Also the &#x60;aggregations[shipping-free]&#x60; key will be removed from the response.
    * @return shippingFreeFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -812,7 +790,6 @@ public class ReadCmsRequest {
    * Enables/disabled filtering by properties products. If set to false, the &#x60;properties&#x60; filter will be ignored. Also the &#x60;aggregations[properties]&#x60; key will be removed from the response.
    * @return propertyFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -838,7 +815,6 @@ public class ReadCmsRequest {
    * A whitelist of property identifiers which can be used for filtering. List of property identifiers separated by a &#x60;|&#x60;. The &#x60;property-filter&#x60; must be &#x60;true&#x60;, otherwise the whitelist has no effect.
    * @return propertyWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -864,7 +840,6 @@ public class ReadCmsRequest {
    * By sending the parameter &#x60;reduce-aggregations&#x60; , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.
    * @return reduceAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getReduceAggregations() {
@@ -898,7 +873,6 @@ public class ReadCmsRequest {
    * Resolves only the given slot identifiers. The identifiers have to be seperated by a &#x60;|&#x60; character.
    * @return slots
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SLOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1012,4 +986,3 @@ public class ReadCmsRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadCountry200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadCountry200Response.java
@@ -71,7 +71,6 @@ public class ReadCountry200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadCountry200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadCountry200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadCountry200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadCountry200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadCountry200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadCountry200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadCountry200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadCountryState200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadCountryState200Response.java
@@ -71,7 +71,6 @@ public class ReadCountryState200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadCountryState200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadCountryState200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadCountryState200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadCountryState200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadCountryState200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadCountryState200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadCountryState200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadCurrency200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadCurrency200Response.java
@@ -71,7 +71,6 @@ public class ReadCurrency200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadCurrency200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadCurrency200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadCurrency200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadCurrency200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadCurrency200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadCurrency200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadCurrency200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadLandingPageRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadLandingPageRequest.java
@@ -189,7 +189,6 @@ public class ReadLandingPageRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -216,7 +215,6 @@ public class ReadLandingPageRequest {
    * minimum: 0
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -250,7 +248,6 @@ public class ReadLandingPageRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -284,7 +281,6 @@ public class ReadLandingPageRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -318,7 +314,6 @@ public class ReadLandingPageRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -344,7 +339,6 @@ public class ReadLandingPageRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -378,7 +372,6 @@ public class ReadLandingPageRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -412,7 +405,6 @@ public class ReadLandingPageRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -446,7 +438,6 @@ public class ReadLandingPageRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -472,7 +463,6 @@ public class ReadLandingPageRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -498,7 +488,6 @@ public class ReadLandingPageRequest {
    * Resolves only the given slot identifiers. The identifiers have to be seperated by a &#x60;|&#x60; character.
    * @return slots
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SLOTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -524,7 +513,6 @@ public class ReadLandingPageRequest {
    * Specifies the sorting of the products by &#x60;availableSortings&#x60;. If not set, the default sorting will be set according to the shop settings. The available sorting options are sent within the response under the &#x60;availableSortings&#x60; key. In order to sort by a field, consider using the &#x60;sort&#x60; parameter from the listing criteria. Do not use both parameters together, as it might lead to unexpected results.
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -550,7 +538,6 @@ public class ReadLandingPageRequest {
    * Search result page
    * @return p
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_P)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -576,7 +563,6 @@ public class ReadLandingPageRequest {
    * Filter by manufacturers. List of manufacturer identifiers separated by a &#x60;|&#x60;.
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -603,7 +589,6 @@ public class ReadLandingPageRequest {
    * minimum: 0
    * @return minPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -630,7 +615,6 @@ public class ReadLandingPageRequest {
    * minimum: 0
    * @return maxPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -656,7 +640,6 @@ public class ReadLandingPageRequest {
    * Filter products with a minimum average rating.
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -682,7 +665,6 @@ public class ReadLandingPageRequest {
    * Filters products that are marked as shipping-free.
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -708,7 +690,6 @@ public class ReadLandingPageRequest {
    * Filters products by their properties. List of property identifiers separated by a &#x60;|&#x60;.
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -734,7 +715,6 @@ public class ReadLandingPageRequest {
    * Enables/disabled filtering by manufacturer. If set to false, the &#x60;manufacturer&#x60; filter will be ignored. Also the &#x60;aggregations[manufacturer]&#x60; key will be removed from the response.
    * @return manufacturerFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -760,7 +740,6 @@ public class ReadLandingPageRequest {
    * Enables/disabled filtering by price. If set to false, the &#x60;min-price&#x60; and &#x60;max-price&#x60; filter will be ignored. Also the &#x60;aggregations[price]&#x60; key will be removed from the response.
    * @return priceFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -786,7 +765,6 @@ public class ReadLandingPageRequest {
    * Enables/disabled filtering by rating. If set to false, the &#x60;rating&#x60; filter will be ignored. Also the &#x60;aggregations[rating]&#x60; key will be removed from the response.
    * @return ratingFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -812,7 +790,6 @@ public class ReadLandingPageRequest {
    * Enables/disabled filtering by shipping-free products. If set to false, the &#x60;shipping-free&#x60; filter will be ignored. Also the &#x60;aggregations[shipping-free]&#x60; key will be removed from the response.
    * @return shippingFreeFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -838,7 +815,6 @@ public class ReadLandingPageRequest {
    * Enables/disabled filtering by properties products. If set to false, the &#x60;properties&#x60; filter will be ignored. Also the &#x60;aggregations[properties]&#x60; key will be removed from the response.
    * @return propertyFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -864,7 +840,6 @@ public class ReadLandingPageRequest {
    * A whitelist of property identifiers which can be used for filtering. List of property identifiers separated by a &#x60;|&#x60;. The &#x60;property-filter&#x60; must be &#x60;true&#x60;, otherwise the whitelist has no effect.
    * @return propertyWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -890,7 +865,6 @@ public class ReadLandingPageRequest {
    * By sending the parameter &#x60;reduce-aggregations&#x60; , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.
    * @return reduceAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getReduceAggregations() {
@@ -1012,4 +986,3 @@ public class ReadLandingPageRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadLanguages200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadLanguages200Response.java
@@ -71,7 +71,6 @@ public class ReadLanguages200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadLanguages200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadLanguages200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadLanguages200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadLanguages200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadLanguages200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadLanguages200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadLanguages200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadNavigationRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadNavigationRequest.java
@@ -130,7 +130,6 @@ public class ReadNavigationRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -156,7 +155,6 @@ public class ReadNavigationRequest {
    * Number of items per result page
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -190,7 +188,6 @@ public class ReadNavigationRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -224,7 +221,6 @@ public class ReadNavigationRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -258,7 +254,6 @@ public class ReadNavigationRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -284,7 +279,6 @@ public class ReadNavigationRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -318,7 +312,6 @@ public class ReadNavigationRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -352,7 +345,6 @@ public class ReadNavigationRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -386,7 +378,6 @@ public class ReadNavigationRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -412,7 +403,6 @@ public class ReadNavigationRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -438,7 +428,6 @@ public class ReadNavigationRequest {
    * Determines the depth of fetched navigation levels.
    * @return depth
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEPTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -472,7 +461,6 @@ public class ReadNavigationRequest {
    * Return the categories as a tree or as a flat list.
    * @return buildTree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BUILD_TREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -547,4 +535,3 @@ public class ReadNavigationRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadOrderRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadOrderRequest.java
@@ -126,7 +126,6 @@ public class ReadOrderRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -152,7 +151,6 @@ public class ReadOrderRequest {
    * Number of items per result page
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -186,7 +184,6 @@ public class ReadOrderRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -220,7 +217,6 @@ public class ReadOrderRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -254,7 +250,6 @@ public class ReadOrderRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -280,7 +275,6 @@ public class ReadOrderRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -314,7 +308,6 @@ public class ReadOrderRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -348,7 +341,6 @@ public class ReadOrderRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -382,7 +374,6 @@ public class ReadOrderRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -408,7 +399,6 @@ public class ReadOrderRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -434,7 +424,6 @@ public class ReadOrderRequest {
    * Check if the payment method of the order is still changeable.
    * @return checkPromotion
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CHECK_PROMOTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -507,4 +496,3 @@ public class ReadOrderRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadPaymentMethod200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadPaymentMethod200Response.java
@@ -55,7 +55,6 @@ public class ReadPaymentMethod200Response {
    * Total amount
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -81,7 +80,6 @@ public class ReadPaymentMethod200Response {
    * aggregation result
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -115,7 +113,6 @@ public class ReadPaymentMethod200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,4 +169,3 @@ public class ReadPaymentMethod200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadPaymentMethodRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadPaymentMethodRequest.java
@@ -126,7 +126,6 @@ public class ReadPaymentMethodRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -152,7 +151,6 @@ public class ReadPaymentMethodRequest {
    * Number of items per result page
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -186,7 +184,6 @@ public class ReadPaymentMethodRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -220,7 +217,6 @@ public class ReadPaymentMethodRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -254,7 +250,6 @@ public class ReadPaymentMethodRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -280,7 +275,6 @@ public class ReadPaymentMethodRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -314,7 +308,6 @@ public class ReadPaymentMethodRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -348,7 +341,6 @@ public class ReadPaymentMethodRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -382,7 +374,6 @@ public class ReadPaymentMethodRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -408,7 +399,6 @@ public class ReadPaymentMethodRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -434,7 +424,6 @@ public class ReadPaymentMethodRequest {
    * List only available
    * @return onlyAvailable
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ONLY_AVAILABLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -507,4 +496,3 @@ public class ReadPaymentMethodRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadProduct200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadProduct200Response.java
@@ -71,7 +71,6 @@ public class ReadProduct200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadProduct200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadProduct200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadProduct200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadProduct200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadProduct200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadProduct200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadProduct200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadProductListingRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadProductListingRequest.java
@@ -193,7 +193,6 @@ public class ReadProductListingRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -220,7 +219,6 @@ public class ReadProductListingRequest {
    * minimum: 0
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -254,7 +252,6 @@ public class ReadProductListingRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -288,7 +285,6 @@ public class ReadProductListingRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,7 +318,6 @@ public class ReadProductListingRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -348,7 +343,6 @@ public class ReadProductListingRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -382,7 +376,6 @@ public class ReadProductListingRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -416,7 +409,6 @@ public class ReadProductListingRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -450,7 +442,6 @@ public class ReadProductListingRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -476,7 +467,6 @@ public class ReadProductListingRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -502,7 +492,6 @@ public class ReadProductListingRequest {
    * Specifies the sorting of the products by &#x60;availableSortings&#x60;. If not set, the default sorting will be set according to the shop settings. The available sorting options are sent within the response under the &#x60;availableSortings&#x60; key. In order to sort by a field, consider using the &#x60;sort&#x60; parameter from the listing criteria. Do not use both parameters together, as it might lead to unexpected results.
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -528,7 +517,6 @@ public class ReadProductListingRequest {
    * Search result page
    * @return p
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_P)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -554,7 +542,6 @@ public class ReadProductListingRequest {
    * Filter by manufacturers. List of manufacturer identifiers separated by a &#x60;|&#x60;.
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -581,7 +568,6 @@ public class ReadProductListingRequest {
    * minimum: 0
    * @return minPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -608,7 +594,6 @@ public class ReadProductListingRequest {
    * minimum: 0
    * @return maxPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -634,7 +619,6 @@ public class ReadProductListingRequest {
    * Filter products with a minimum average rating.
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -660,7 +644,6 @@ public class ReadProductListingRequest {
    * Filters products that are marked as shipping-free.
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -686,7 +669,6 @@ public class ReadProductListingRequest {
    * Filters products by their properties. List of property identifiers separated by a &#x60;|&#x60;.
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -712,7 +694,6 @@ public class ReadProductListingRequest {
    * Enables/disabled filtering by manufacturer. If set to false, the &#x60;manufacturer&#x60; filter will be ignored. Also the &#x60;aggregations[manufacturer]&#x60; key will be removed from the response.
    * @return manufacturerFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -738,7 +719,6 @@ public class ReadProductListingRequest {
    * Enables/disabled filtering by price. If set to false, the &#x60;min-price&#x60; and &#x60;max-price&#x60; filter will be ignored. Also the &#x60;aggregations[price]&#x60; key will be removed from the response.
    * @return priceFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -764,7 +744,6 @@ public class ReadProductListingRequest {
    * Enables/disabled filtering by rating. If set to false, the &#x60;rating&#x60; filter will be ignored. Also the &#x60;aggregations[rating]&#x60; key will be removed from the response.
    * @return ratingFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -790,7 +769,6 @@ public class ReadProductListingRequest {
    * Enables/disabled filtering by shipping-free products. If set to false, the &#x60;shipping-free&#x60; filter will be ignored. Also the &#x60;aggregations[shipping-free]&#x60; key will be removed from the response.
    * @return shippingFreeFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -816,7 +794,6 @@ public class ReadProductListingRequest {
    * Enables/disabled filtering by properties products. If set to false, the &#x60;properties&#x60; filter will be ignored. Also the &#x60;aggregations[properties]&#x60; key will be removed from the response.
    * @return propertyFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -842,7 +819,6 @@ public class ReadProductListingRequest {
    * A whitelist of property identifiers which can be used for filtering. List of property identifiers separated by a &#x60;|&#x60;. The &#x60;property-filter&#x60; must be &#x60;true&#x60;, otherwise the whitelist has no effect.
    * @return propertyWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -868,7 +844,6 @@ public class ReadProductListingRequest {
    * By sending the parameter &#x60;reduce-aggregations&#x60; , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.
    * @return reduceAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getReduceAggregations() {
@@ -902,7 +877,6 @@ public class ReadProductListingRequest {
    * Resets all aggregations in the criteria. This parameter is a flag, the value has no effect.
    * @return noAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getNoAggregations() {
@@ -936,7 +910,6 @@ public class ReadProductListingRequest {
    * If this flag is set, no products are fetched. Sorting and associations are also ignored. This parameter is a flag, the value has no effect.
    * @return onlyAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getOnlyAggregations() {
@@ -1060,4 +1033,3 @@ public class ReadProductListingRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadProductReviews200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadProductReviews200Response.java
@@ -71,7 +71,6 @@ public class ReadProductReviews200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadProductReviews200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadProductReviews200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadProductReviews200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadProductReviews200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadProductReviews200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadProductReviews200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadProductReviews200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadSalutation200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadSalutation200Response.java
@@ -71,7 +71,6 @@ public class ReadSalutation200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadSalutation200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadSalutation200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadSalutation200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadSalutation200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadSalutation200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadSalutation200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadSalutation200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadSeoUrl200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadSeoUrl200Response.java
@@ -71,7 +71,6 @@ public class ReadSeoUrl200Response {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class ReadSeoUrl200Response {
    * Get entity
    * @return entity
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +121,6 @@ public class ReadSeoUrl200Response {
    * The total number of found entities
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -157,7 +154,6 @@ public class ReadSeoUrl200Response {
    * Contains aggregated data. A simple example is the determination of the average price from a product search query.
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -183,7 +179,6 @@ public class ReadSeoUrl200Response {
    * The actual page. This can be used for pagination.
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -209,7 +204,6 @@ public class ReadSeoUrl200Response {
    * The actual limit. This is used for pagination and goes together with the page.
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +237,6 @@ public class ReadSeoUrl200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -308,4 +301,3 @@ public class ReadSeoUrl200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ReadShippingMethod200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ReadShippingMethod200Response.java
@@ -55,7 +55,6 @@ public class ReadShippingMethod200Response {
    * Total amount
    * @return total
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -81,7 +80,6 @@ public class ReadShippingMethod200Response {
    * aggregation result
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -115,7 +113,6 @@ public class ReadShippingMethod200Response {
    * Get elements
    * @return elements
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ELEMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,4 +169,3 @@ public class ReadShippingMethod200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RecoveryPasswordRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RecoveryPasswordRequest.java
@@ -53,7 +53,6 @@ public class RecoveryPasswordRequest {
    * Parameter from the link in the confirmation mail sent in Step 1
    * @return hash
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HASH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -79,7 +78,6 @@ public class RecoveryPasswordRequest {
    * New password for the customer
    * @return newPassword
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NEW_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -105,7 +103,6 @@ public class RecoveryPasswordRequest {
    * Confirmation of the new password
    * @return newPasswordConfirm
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NEW_PASSWORD_CONFIRM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,4 +159,3 @@ public class RecoveryPasswordRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RegisterConfirmRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RegisterConfirmRequest.java
@@ -49,7 +49,6 @@ public class RegisterConfirmRequest {
    * Hash from the email received
    * @return hash
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HASH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -75,7 +74,6 @@ public class RegisterConfirmRequest {
    * Email hash from the email received
    * @return em
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EM)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,4 +128,3 @@ public class RegisterConfirmRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RegisterRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RegisterRequest.java
@@ -109,7 +109,6 @@ public class RegisterRequest {
    * Email of the customer. Has to be unique, unless &#x60;guest&#x60; is &#x60;true&#x60;
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -135,7 +134,6 @@ public class RegisterRequest {
    * Password for the customer. Required, unless &#x60;guest&#x60; is &#x60;true&#x60;
    * @return password
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -161,7 +159,6 @@ public class RegisterRequest {
    * Id of the salutation for the customer account. Fetch options using &#x60;salutation&#x60; endpoint.
    * @return salutationId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -187,7 +184,6 @@ public class RegisterRequest {
    * Customer first name. Value will be reused for shipping and billing address if not provided explicitly.
    * @return firstName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -213,7 +209,6 @@ public class RegisterRequest {
    * Customer last name. Value will be reused for shipping and billing address if not provided explicitly.
    * @return lastName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -239,7 +234,6 @@ public class RegisterRequest {
    * Flag indicating accepted data protection
    * @return acceptedDataProtection
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ACCEPTED_DATA_PROTECTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -265,7 +259,6 @@ public class RegisterRequest {
    * URL of the storefront for that registration. Used in confirmation emails. Has to be one of the configured domains of the sales channel.
    * @return storefrontUrl
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STOREFRONT_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -291,7 +284,6 @@ public class RegisterRequest {
    * Get billingAddress
    * @return billingAddress
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_BILLING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -317,7 +309,6 @@ public class RegisterRequest {
    * Get shippingAddress
    * @return shippingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -343,7 +334,6 @@ public class RegisterRequest {
    * Account type of the customer which can be either &#x60;private&#x60; or &#x60;business&#x60;.
    * @return accountType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACCOUNT_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -369,7 +359,6 @@ public class RegisterRequest {
    * If set, will create a guest customer. Guest customers can re-use an email address and don&#39;t need a password.
    * @return guest
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GUEST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -395,7 +384,6 @@ public class RegisterRequest {
    * Birthday day
    * @return birthdayDay
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY_DAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -421,7 +409,6 @@ public class RegisterRequest {
    * Birthday month
    * @return birthdayMonth
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY_MONTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -447,7 +434,6 @@ public class RegisterRequest {
    * Birthday year
    * @return birthdayYear
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY_YEAR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -473,7 +459,6 @@ public class RegisterRequest {
    * (Academic) title of the customer
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -499,7 +484,6 @@ public class RegisterRequest {
    * Field can be used to store an affiliate tracking code
    * @return affiliateCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFFILIATE_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -525,7 +509,6 @@ public class RegisterRequest {
    * Field can be used to store a campaign tracking code
    * @return campaignCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAMPAIGN_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -610,4 +593,3 @@ public class RegisterRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RelationshipLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RelationshipLinks.java
@@ -51,7 +51,6 @@ public class RelationshipLinks extends HashMap<String, Object> {
    * Get self
    * @return self
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SELF)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -77,7 +76,6 @@ public class RelationshipLinks extends HashMap<String, Object> {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -134,4 +132,3 @@ public class RelationshipLinks extends HashMap<String, Object> {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RelationshipLinksSelf.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RelationshipLinksSelf.java
@@ -51,7 +51,6 @@ public class RelationshipLinksSelf {
    * A string containing the link&#39;s URL.
    * @return href
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_HREF)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -85,7 +84,6 @@ public class RelationshipLinksSelf {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class RelationshipLinksSelf {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RelationshipToOne.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RelationshipToOne.java
@@ -55,7 +55,6 @@ public class RelationshipToOne {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -81,7 +80,6 @@ public class RelationshipToOne {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -115,7 +113,6 @@ public class RelationshipToOne {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,4 +169,3 @@ public class RelationshipToOne {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Relationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Relationships.java
@@ -49,7 +49,6 @@ public class Relationships {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class Relationships {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class Relationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RelationshipsData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RelationshipsData.java
@@ -55,7 +55,6 @@ public class RelationshipsData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -81,7 +80,6 @@ public class RelationshipsData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -115,7 +113,6 @@ public class RelationshipsData {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -172,4 +169,3 @@ public class RelationshipsData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RemoveLineItemRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RemoveLineItemRequest.java
@@ -55,7 +55,6 @@ public class RemoveLineItemRequest {
    * A list of product identifiers.
    * @return ids
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_IDS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -108,4 +107,3 @@ public class RemoveLineItemRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Resource.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Resource.java
@@ -70,7 +70,6 @@ public class Resource {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -96,7 +95,6 @@ public class Resource {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,7 +128,6 @@ public class Resource {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -156,7 +153,6 @@ public class Resource {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -198,7 +194,6 @@ public class Resource {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -232,7 +227,6 @@ public class Resource {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -306,4 +300,3 @@ public class Resource {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Rule.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Rule.java
@@ -75,7 +75,6 @@ public class Rule {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class Rule {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -127,7 +125,6 @@ public class Rule {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +150,6 @@ public class Rule {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +169,6 @@ public class Rule {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -188,7 +183,6 @@ public class Rule {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -246,4 +240,3 @@ public class Rule {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/RuleCondition.java
+++ b/src/main/java/de/codebarista/shopware/model/core/RuleCondition.java
@@ -63,7 +63,6 @@ public class RuleCondition {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class RuleCondition {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class RuleCondition {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class RuleCondition {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannel.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannel.java
@@ -201,7 +201,6 @@ public class SalesChannel {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -227,7 +226,6 @@ public class SalesChannel {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -253,7 +251,6 @@ public class SalesChannel {
    * Get customerGroupId
    * @return customerGroupId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CUSTOMER_GROUP_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -279,7 +276,6 @@ public class SalesChannel {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -305,7 +301,6 @@ public class SalesChannel {
    * Get paymentMethodId
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -331,7 +326,6 @@ public class SalesChannel {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -357,7 +351,6 @@ public class SalesChannel {
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -383,7 +376,6 @@ public class SalesChannel {
    * Get navigationCategoryId
    * @return navigationCategoryId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -409,7 +401,6 @@ public class SalesChannel {
    * Get navigationCategoryVersionId
    * @return navigationCategoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -435,7 +426,6 @@ public class SalesChannel {
    * Get navigationCategoryDepth
    * @return navigationCategoryDepth
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_DEPTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -461,7 +451,6 @@ public class SalesChannel {
    * Get footerCategoryId
    * @return footerCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -487,7 +476,6 @@ public class SalesChannel {
    * Get footerCategoryVersionId
    * @return footerCategoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -513,7 +501,6 @@ public class SalesChannel {
    * Get serviceCategoryId
    * @return serviceCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SERVICE_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -539,7 +526,6 @@ public class SalesChannel {
    * Get serviceCategoryVersionId
    * @return serviceCategoryVersionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SERVICE_CATEGORY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -565,7 +551,6 @@ public class SalesChannel {
    * Get mailHeaderFooterId
    * @return mailHeaderFooterId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAIL_HEADER_FOOTER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -591,7 +576,6 @@ public class SalesChannel {
    * Get hreflangDefaultDomainId
    * @return hreflangDefaultDomainId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_DEFAULT_DOMAIN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -617,7 +601,6 @@ public class SalesChannel {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -643,7 +626,6 @@ public class SalesChannel {
    * Get shortName
    * @return shortName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -669,7 +651,6 @@ public class SalesChannel {
    * Get taxCalculationType
    * @return taxCalculationType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_CALCULATION_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -695,7 +676,6 @@ public class SalesChannel {
    * Get _configuration
    * @return _configuration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONFIGURATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -721,7 +701,6 @@ public class SalesChannel {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -747,7 +726,6 @@ public class SalesChannel {
    * Get hreflangActive
    * @return hreflangActive
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -773,7 +751,6 @@ public class SalesChannel {
    * Get maintenance
    * @return maintenance
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAINTENANCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -799,7 +776,6 @@ public class SalesChannel {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -819,7 +795,6 @@ public class SalesChannel {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -834,7 +809,6 @@ public class SalesChannel {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -855,7 +829,6 @@ public class SalesChannel {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -881,7 +854,6 @@ public class SalesChannel {
    * Get language
    * @return language
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -907,7 +879,6 @@ public class SalesChannel {
    * Get currency
    * @return currency
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -933,7 +904,6 @@ public class SalesChannel {
    * Get paymentMethod
    * @return paymentMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -959,7 +929,6 @@ public class SalesChannel {
    * Get shippingMethod
    * @return shippingMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -985,7 +954,6 @@ public class SalesChannel {
    * Get country
    * @return country
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1019,7 +987,6 @@ public class SalesChannel {
    * Get domains
    * @return domains
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOMAINS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1045,7 +1012,6 @@ public class SalesChannel {
    * Get navigationCategory
    * @return navigationCategory
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1071,7 +1037,6 @@ public class SalesChannel {
    * Get footerCategory
    * @return footerCategory
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1097,7 +1062,6 @@ public class SalesChannel {
    * Get serviceCategory
    * @return serviceCategory
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SERVICE_CATEGORY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1123,7 +1087,6 @@ public class SalesChannel {
    * Get hreflangDefaultDomain
    * @return hreflangDefaultDomain
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_DEFAULT_DOMAIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1248,4 +1211,3 @@ public class SalesChannel {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelAnalytics.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelAnalytics.java
@@ -63,7 +63,6 @@ public class SalesChannelAnalytics {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class SalesChannelAnalytics {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class SalesChannelAnalytics {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class SalesChannelAnalytics {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContext.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContext.java
@@ -85,7 +85,6 @@ public class SalesChannelContext {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -111,7 +110,6 @@ public class SalesChannelContext {
    * Context the user session
    * @return token
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -137,7 +135,6 @@ public class SalesChannelContext {
    * Get currentCustomerGroup
    * @return currentCustomerGroup
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENT_CUSTOMER_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +160,6 @@ public class SalesChannelContext {
    * Get fallbackCustomerGroup
    * @return fallbackCustomerGroup
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FALLBACK_CUSTOMER_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -189,7 +185,6 @@ public class SalesChannelContext {
    * Get currency
    * @return currency
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -215,7 +210,6 @@ public class SalesChannelContext {
    * Get salesChannel
    * @return salesChannel
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -249,7 +243,6 @@ public class SalesChannelContext {
    * Currently active tax rules and/or rates
    * @return taxRules
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_RULES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -275,7 +268,6 @@ public class SalesChannelContext {
    * Get customer
    * @return customer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -301,7 +293,6 @@ public class SalesChannelContext {
    * Get paymentMethod
    * @return paymentMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -327,7 +318,6 @@ public class SalesChannelContext {
    * Get shippingMethod
    * @return shippingMethod
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -353,7 +343,6 @@ public class SalesChannelContext {
    * Get context
    * @return context
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONTEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -426,4 +415,3 @@ public class SalesChannelContext {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfContext.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfContext.java
@@ -73,7 +73,6 @@ public class SalesChannelContextAllOfContext {
    * Get versionId
    * @return versionId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VERSION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -99,7 +98,6 @@ public class SalesChannelContextAllOfContext {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +123,6 @@ public class SalesChannelContextAllOfContext {
    * Get currencyFactor
    * @return currencyFactor
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_FACTOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +148,6 @@ public class SalesChannelContextAllOfContext {
    * Get currencyPrecision
    * @return currencyPrecision
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_PRECISION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class SalesChannelContextAllOfContext {
    * Get scope
    * @return scope
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SCOPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class SalesChannelContextAllOfContext {
    * Get source
    * @return source
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SOURCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +223,6 @@ public class SalesChannelContextAllOfContext {
    * Get taxState
    * @return taxState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +248,6 @@ public class SalesChannelContextAllOfContext {
    * Get useCache
    * @return useCache
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_USE_CACHE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,4 +314,3 @@ public class SalesChannelContextAllOfContext {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfCurrency.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfCurrency.java
@@ -73,7 +73,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get isoCode
    * @return isoCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ISO_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -99,7 +98,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get factor
    * @return factor
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FACTOR)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +123,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get symbol
    * @return symbol
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SYMBOL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +148,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get shortName
    * @return shortName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +223,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get decimalPrecision
    * @return decimalPrecision
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DECIMAL_PRECISION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +248,6 @@ public class SalesChannelContextAllOfCurrency {
    * Get isSystemDefault
    * @return isSystemDefault
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_SYSTEM_DEFAULT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,4 +314,3 @@ public class SalesChannelContextAllOfCurrency {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfCurrentCustomerGroup.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfCurrentCustomerGroup.java
@@ -49,7 +49,6 @@ public class SalesChannelContextAllOfCurrentCustomerGroup {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class SalesChannelContextAllOfCurrentCustomerGroup {
    * Get displayGross
    * @return displayGross
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISPLAY_GROSS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class SalesChannelContextAllOfCurrentCustomerGroup {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfCustomer.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfCustomer.java
@@ -190,7 +190,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get groupId
    * @return groupId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -216,7 +215,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get defaultPaymentMethodId
    * @return defaultPaymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -242,7 +240,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -268,7 +265,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -294,7 +290,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get lastPaymentMethodId
    * @return lastPaymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -320,7 +315,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get defaultBillingAddressId
    * @return defaultBillingAddressId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_BILLING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -346,7 +340,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get defaultShippingAddressId
    * @return defaultShippingAddressId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_SHIPPING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -372,7 +365,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get defaultBillingAddress
    * @return defaultBillingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_BILLING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -398,7 +390,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get defaultShippingAddress
    * @return defaultShippingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DEFAULT_SHIPPING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -424,7 +415,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get activeBillingAddress
    * @return activeBillingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE_BILLING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -450,7 +440,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get activeShippingAddress
    * @return activeShippingAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE_SHIPPING_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -476,7 +465,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get customerNumber
    * @return customerNumber
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_NUMBER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -502,7 +490,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get salutationId
    * @return salutationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -528,7 +515,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get firstName
    * @return firstName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -554,7 +540,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get lastName
    * @return lastName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -580,7 +565,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get company
    * @return company
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COMPANY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -606,7 +590,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get password
    * @return password
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -632,7 +615,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get email
    * @return email
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -658,7 +640,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -684,7 +665,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get affiliateCode
    * @return affiliateCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AFFILIATE_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -710,7 +690,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get campaignCode
    * @return campaignCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CAMPAIGN_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -736,7 +715,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -762,7 +740,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get doubleOptInRegistration
    * @return doubleOptInRegistration
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOUBLE_OPT_IN_REGISTRATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -788,7 +765,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get doubleOptInEmailSentDate
    * @return doubleOptInEmailSentDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOUBLE_OPT_IN_EMAIL_SENT_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -814,7 +790,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get doubleOptInConfirmDate
    * @return doubleOptInConfirmDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DOUBLE_OPT_IN_CONFIRM_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -840,7 +815,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get hash
    * @return hash
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HASH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -866,7 +840,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get guest
    * @return guest
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GUEST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -892,7 +865,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get firstLogin
    * @return firstLogin
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST_LOGIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -918,7 +890,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get lastLogin
    * @return lastLogin
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_LOGIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -944,7 +915,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get newsletter
    * @return newsletter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NEWSLETTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -970,7 +940,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get birthday
    * @return birthday
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BIRTHDAY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -996,7 +965,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get lastOrderDate
    * @return lastOrderDate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_ORDER_DATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1022,7 +990,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get orderCount
    * @return orderCount
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_COUNT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1048,7 +1015,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get legacyEncoder
    * @return legacyEncoder
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LEGACY_ENCODER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1074,7 +1040,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get legacyPassword
    * @return legacyPassword
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LEGACY_PASSWORD)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1100,7 +1065,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get autoIncrement
    * @return autoIncrement
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AUTO_INCREMENT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1126,7 +1090,6 @@ public class SalesChannelContextAllOfCustomer {
    * Get remoteAddress
    * @return remoteAddress
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REMOTE_ADDRESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -1251,4 +1214,3 @@ public class SalesChannelContextAllOfCustomer {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfFallbackCustomerGroup.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfFallbackCustomerGroup.java
@@ -49,7 +49,6 @@ public class SalesChannelContextAllOfFallbackCustomerGroup {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class SalesChannelContextAllOfFallbackCustomerGroup {
    * Get displayGross
    * @return displayGross
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DISPLAY_GROSS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class SalesChannelContextAllOfFallbackCustomerGroup {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfPaymentMethod.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfPaymentMethod.java
@@ -77,7 +77,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get pluginId
    * @return pluginId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PLUGIN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -103,7 +102,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get handlerIdentifier
    * @return handlerIdentifier
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HANDLER_IDENTIFIER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -129,7 +127,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -155,7 +152,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -181,7 +177,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -207,7 +202,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -233,7 +227,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get availabilityRuleId
    * @return availabilityRuleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABILITY_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -259,7 +252,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +277,6 @@ public class SalesChannelContextAllOfPaymentMethod {
    * Get formattedHandlerIdentifier
    * @return formattedHandlerIdentifier
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FORMATTED_HANDLER_IDENTIFIER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -354,4 +345,3 @@ public class SalesChannelContextAllOfPaymentMethod {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfSalesChannel.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfSalesChannel.java
@@ -125,7 +125,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get typeId
    * @return typeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +150,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +175,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +200,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get paymentMethodId
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +225,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +250,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -281,7 +275,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get navigationCategoryId
    * @return navigationCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -307,7 +300,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get navigationCategoryDepth
    * @return navigationCategoryDepth
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_DEPTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -333,7 +325,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get footerCategoryId
    * @return footerCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -359,7 +350,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get serviceCategoryId
    * @return serviceCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SERVICE_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -385,7 +375,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -411,7 +400,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get shortName
    * @return shortName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -437,7 +425,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get accessKey
    * @return accessKey
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACCESS_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -463,7 +450,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -489,7 +475,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get maintenance
    * @return maintenance
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAINTENANCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -515,7 +500,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get maintenanceIpWhitelist
    * @return maintenanceIpWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAINTENANCE_IP_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -541,7 +525,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get mailHeaderFooterId
    * @return mailHeaderFooterId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAIL_HEADER_FOOTER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -567,7 +550,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get customerGroupId
    * @return customerGroupId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_GROUP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -593,7 +575,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get hreflangActive
    * @return hreflangActive
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -619,7 +600,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get hreflangDefaultDomainId
    * @return hreflangDefaultDomainId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_DEFAULT_DOMAIN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -645,7 +625,6 @@ public class SalesChannelContextAllOfSalesChannel {
    * Get analyticsId
    * @return analyticsId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ANALYTICS_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -738,4 +717,3 @@ public class SalesChannelContextAllOfSalesChannel {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfShippingMethod.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfShippingMethod.java
@@ -69,7 +69,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -95,7 +94,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -121,7 +119,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +144,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get trackingUrl
    * @return trackingUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRACKING_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +169,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get deliveryTimeId
    * @return deliveryTimeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +194,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get availabilityRuleId
    * @return availabilityRuleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABILITY_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +219,6 @@ public class SalesChannelContextAllOfShippingMethod {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -290,4 +283,3 @@ public class SalesChannelContextAllOfShippingMethod {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfTaxRules.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelContextAllOfTaxRules.java
@@ -49,7 +49,6 @@ public class SalesChannelContextAllOfTaxRules {
    * Get taxRate
    * @return taxRate
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX_RATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class SalesChannelContextAllOfTaxRules {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class SalesChannelContextAllOfTaxRules {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelDomain.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelDomain.java
@@ -103,7 +103,6 @@ public class SalesChannelDomain {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -129,7 +128,6 @@ public class SalesChannelDomain {
    * Get url
    * @return url
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -155,7 +153,6 @@ public class SalesChannelDomain {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -181,7 +178,6 @@ public class SalesChannelDomain {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -207,7 +203,6 @@ public class SalesChannelDomain {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -233,7 +228,6 @@ public class SalesChannelDomain {
    * Get snippetSetId
    * @return snippetSetId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SNIPPET_SET_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -259,7 +253,6 @@ public class SalesChannelDomain {
    * Get hreflangUseOnlyLocale
    * @return hreflangUseOnlyLocale
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_USE_ONLY_LOCALE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -285,7 +278,6 @@ public class SalesChannelDomain {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -305,7 +297,6 @@ public class SalesChannelDomain {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -320,7 +311,6 @@ public class SalesChannelDomain {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -341,7 +331,6 @@ public class SalesChannelDomain {
    * Get language
    * @return language
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -367,7 +356,6 @@ public class SalesChannelDomain {
    * Get currency
    * @return currency
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -393,7 +381,6 @@ public class SalesChannelDomain {
    * Get salesChannelDefaultHreflang
    * @return salesChannelDefaultHreflang
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_DEFAULT_HREFLANG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -470,4 +457,3 @@ public class SalesChannelDomain {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalesChannelType.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalesChannelType.java
@@ -67,7 +67,6 @@ public class SalesChannelType {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class SalesChannelType {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class SalesChannelType {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class SalesChannelType {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class SalesChannelType {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Salutation.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Salutation.java
@@ -83,7 +83,6 @@ public class Salutation {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +108,6 @@ public class Salutation {
    * Get salutationKey
    * @return salutationKey
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALUTATION_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -135,7 +133,6 @@ public class Salutation {
    * Get displayName
    * @return displayName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DISPLAY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -161,7 +158,6 @@ public class Salutation {
    * Get letterName
    * @return letterName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LETTER_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -187,7 +183,6 @@ public class Salutation {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -207,7 +202,6 @@ public class Salutation {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -222,7 +216,6 @@ public class Salutation {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -243,7 +236,6 @@ public class Salutation {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -310,4 +302,3 @@ public class Salutation {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SalutationJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SalutationJsonApi.java
@@ -108,7 +108,6 @@ public class SalutationJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -134,7 +133,6 @@ public class SalutationJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -168,7 +166,6 @@ public class SalutationJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,7 +191,6 @@ public class SalutationJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -236,7 +232,6 @@ public class SalutationJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -270,7 +265,6 @@ public class SalutationJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -296,7 +290,6 @@ public class SalutationJsonApi {
    * Get salutationKey
    * @return salutationKey
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALUTATION_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -322,7 +315,6 @@ public class SalutationJsonApi {
    * Get displayName
    * @return displayName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DISPLAY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -348,7 +340,6 @@ public class SalutationJsonApi {
    * Get letterName
    * @return letterName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LETTER_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -374,7 +365,6 @@ public class SalutationJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -394,7 +384,6 @@ public class SalutationJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -409,7 +398,6 @@ public class SalutationJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -430,7 +418,6 @@ public class SalutationJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -518,4 +505,3 @@ public class SalutationJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SaveProductReviewRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SaveProductReviewRequest.java
@@ -61,7 +61,6 @@ public class SaveProductReviewRequest {
    * The name of the review author. If not set, the first name of the customer is chosen.
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class SaveProductReviewRequest {
    * The email address of the review author. If not set, the email of the customer is chosen.
    * @return email
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -113,7 +111,6 @@ public class SaveProductReviewRequest {
    * The title of the review.
    * @return title
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -139,7 +136,6 @@ public class SaveProductReviewRequest {
    * The content of review.
    * @return content
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CONTENT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -165,7 +161,6 @@ public class SaveProductReviewRequest {
    * The review rating for the product.
    * @return points
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_POINTS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -226,4 +221,3 @@ public class SaveProductReviewRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ScheduledTask.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ScheduledTask.java
@@ -63,7 +63,6 @@ public class ScheduledTask {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ScheduledTask {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class ScheduledTask {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class ScheduledTask {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Script.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Script.java
@@ -63,7 +63,6 @@ public class Script {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class Script {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class Script {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class Script {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SearchPageRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SearchPageRequest.java
@@ -197,7 +197,6 @@ public class SearchPageRequest {
    * Search result page
    * @return page
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAGE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -224,7 +223,6 @@ public class SearchPageRequest {
    * minimum: 0
    * @return limit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LIMIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -258,7 +256,6 @@ public class SearchPageRequest {
    * List of filters to restrict the search result. For more information, see [Search Queries &gt; Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#filter)
    * @return filter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -292,7 +289,6 @@ public class SearchPageRequest {
    * Sorting in the search result.
    * @return sort
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SORT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -326,7 +322,6 @@ public class SearchPageRequest {
    * Filters that applied without affecting aggregations. For more information, see [Search Queries &gt; Post Filter](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#post-filter)
    * @return postFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POST_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -352,7 +347,6 @@ public class SearchPageRequest {
    * Used to fetch associations which are not fetched by default.
    * @return associations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ASSOCIATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -386,7 +380,6 @@ public class SearchPageRequest {
    * Used to perform aggregations on the search result. For more information, see [Search Queries &gt; Aggregations](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#aggregations)
    * @return aggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AGGREGATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -420,7 +413,6 @@ public class SearchPageRequest {
    * Perform groupings over certain fields
    * @return grouping
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_GROUPING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -454,7 +446,6 @@ public class SearchPageRequest {
    * Fields which should be returned in the search result.
    * @return fields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -480,7 +471,6 @@ public class SearchPageRequest {
    * Whether the total for the total number of hits should be determined for the search query. none &#x3D; disabled total count, exact &#x3D; calculate exact total amount (slow), next-pages &#x3D; calculate only for next page (fast)
    * @return totalCountMode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TOTAL_COUNT_MODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -506,7 +496,6 @@ public class SearchPageRequest {
    * Specifies the sorting of the products by &#x60;availableSortings&#x60;. If not set, the default sorting will be set according to the shop settings. The available sorting options are sent within the response under the &#x60;availableSortings&#x60; key. In order to sort by a field, consider using the &#x60;sort&#x60; parameter from the listing criteria. Do not use both parameters together, as it might lead to unexpected results.
    * @return order
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -532,7 +521,6 @@ public class SearchPageRequest {
    * Search result page
    * @return p
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_P)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -558,7 +546,6 @@ public class SearchPageRequest {
    * Filter by manufacturers. List of manufacturer identifiers separated by a &#x60;|&#x60;.
    * @return manufacturer
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -585,7 +572,6 @@ public class SearchPageRequest {
    * minimum: 0
    * @return minPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -612,7 +598,6 @@ public class SearchPageRequest {
    * minimum: 0
    * @return maxPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -638,7 +623,6 @@ public class SearchPageRequest {
    * Filter products with a minimum average rating.
    * @return rating
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -664,7 +648,6 @@ public class SearchPageRequest {
    * Filters products that are marked as shipping-free.
    * @return shippingFree
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -690,7 +673,6 @@ public class SearchPageRequest {
    * Filters products by their properties. List of property identifiers separated by a &#x60;|&#x60;.
    * @return properties
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -716,7 +698,6 @@ public class SearchPageRequest {
    * Enables/disabled filtering by manufacturer. If set to false, the &#x60;manufacturer&#x60; filter will be ignored. Also the &#x60;aggregations[manufacturer]&#x60; key will be removed from the response.
    * @return manufacturerFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MANUFACTURER_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -742,7 +723,6 @@ public class SearchPageRequest {
    * Enables/disabled filtering by price. If set to false, the &#x60;min-price&#x60; and &#x60;max-price&#x60; filter will be ignored. Also the &#x60;aggregations[price]&#x60; key will be removed from the response.
    * @return priceFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -768,7 +748,6 @@ public class SearchPageRequest {
    * Enables/disabled filtering by rating. If set to false, the &#x60;rating&#x60; filter will be ignored. Also the &#x60;aggregations[rating]&#x60; key will be removed from the response.
    * @return ratingFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RATING_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -794,7 +773,6 @@ public class SearchPageRequest {
    * Enables/disabled filtering by shipping-free products. If set to false, the &#x60;shipping-free&#x60; filter will be ignored. Also the &#x60;aggregations[shipping-free]&#x60; key will be removed from the response.
    * @return shippingFreeFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_FREE_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -820,7 +798,6 @@ public class SearchPageRequest {
    * Enables/disabled filtering by properties products. If set to false, the &#x60;properties&#x60; filter will be ignored. Also the &#x60;aggregations[properties]&#x60; key will be removed from the response.
    * @return propertyFilter
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_FILTER)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -846,7 +823,6 @@ public class SearchPageRequest {
    * A whitelist of property identifiers which can be used for filtering. List of property identifiers separated by a &#x60;|&#x60;. The &#x60;property-filter&#x60; must be &#x60;true&#x60;, otherwise the whitelist has no effect.
    * @return propertyWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROPERTY_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -872,7 +848,6 @@ public class SearchPageRequest {
    * By sending the parameter &#x60;reduce-aggregations&#x60; , the post-filters that were applied by the customer, are also applied to the aggregations. This has the consequence that only values are returned in the aggregations that would lead to further filter results. This parameter is a flag, the value has no effect.
    * @return reduceAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getReduceAggregations() {
@@ -906,7 +881,6 @@ public class SearchPageRequest {
    * Resets all aggregations in the criteria. This parameter is a flag, the value has no effect.
    * @return noAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getNoAggregations() {
@@ -940,7 +914,6 @@ public class SearchPageRequest {
    * If this flag is set, no products are fetched. Sorting and associations are also ignored. This parameter is a flag, the value has no effect.
    * @return onlyAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getOnlyAggregations() {
@@ -974,7 +947,6 @@ public class SearchPageRequest {
    * Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag.
    * @return search
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SEARCH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -1092,4 +1064,3 @@ public class SearchPageRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SearchProductVariantIdsRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SearchProductVariantIdsRequest.java
@@ -59,7 +59,6 @@ public class SearchProductVariantIdsRequest {
    * The options parameter for the variant to find.
    * @return options
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_OPTIONS)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -85,7 +84,6 @@ public class SearchProductVariantIdsRequest {
    * The id of the option group that has been switched.
    * @return switchedGroup
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SWITCHED_GROUP)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class SearchProductVariantIdsRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SearchSuggestRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SearchSuggestRequest.java
@@ -56,7 +56,6 @@ public class SearchSuggestRequest {
    * Resets all aggregations in the criteria. This parameter is a flag, the value has no effect.
    * @return noAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getNoAggregations() {
@@ -90,7 +89,6 @@ public class SearchSuggestRequest {
    * If this flag is set, no products are fetched. Sorting and associations are also ignored. This parameter is a flag, the value has no effect.
    * @return onlyAggregations
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public String getOnlyAggregations() {
@@ -124,7 +122,6 @@ public class SearchSuggestRequest {
    * Using the search parameter, the server performs a text search on all records based on their data model and weighting as defined in the entity definition using the SearchRanking flag.
    * @return search
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SEARCH)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,4 +189,3 @@ public class SearchSuggestRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SendContactMailRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SendContactMailRequest.java
@@ -85,7 +85,6 @@ public class SendContactMailRequest {
    * Identifier of the salutation. Use &#x60;/api/salutation&#x60; endpoint to fetch possible values.
    * @return salutationId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -111,7 +110,6 @@ public class SendContactMailRequest {
    * Firstname. This field may be required depending on the system settings.
    * @return firstName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -137,7 +135,6 @@ public class SendContactMailRequest {
    * Lastname. This field may be required depending on the system settings.
    * @return lastName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +160,6 @@ public class SendContactMailRequest {
    * Email address
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -189,7 +185,6 @@ public class SendContactMailRequest {
    * Phone. This field may be required depending on the system settings.
    * @return phone
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PHONE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -215,7 +210,6 @@ public class SendContactMailRequest {
    * The subject of the contact form.
    * @return subject
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SUBJECT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -241,7 +235,6 @@ public class SendContactMailRequest {
    * The message of the contact form
    * @return comment
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_COMMENT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -267,7 +260,6 @@ public class SendContactMailRequest {
    * Identifier of the navigation page. Can be used to override the configuration. Take a look at the settings of a category containing a concact form in the administration.
    * @return navigationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -293,7 +285,6 @@ public class SendContactMailRequest {
    * Identifier of the cms element
    * @return slotId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SLOT_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -319,7 +310,6 @@ public class SendContactMailRequest {
    * Type of the content management page
    * @return cmsPageType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CMS_PAGE_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -345,7 +335,6 @@ public class SendContactMailRequest {
    * Entity name for slot config
    * @return entityName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ENTITY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -418,4 +407,3 @@ public class SendContactMailRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SendRecoveryMailRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SendRecoveryMailRequest.java
@@ -49,7 +49,6 @@ public class SendRecoveryMailRequest {
    * E-Mail address to identify the customer
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -75,7 +74,6 @@ public class SendRecoveryMailRequest {
    * URL of the storefront to use for the generated reset link. It has to be a domain that is configured in the sales channel domain settings.
    * @return storefrontUrl
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STOREFRONT_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -130,4 +128,3 @@ public class SendRecoveryMailRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SeoUrl.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SeoUrl.java
@@ -111,7 +111,6 @@ public class SeoUrl {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -137,7 +136,6 @@ public class SeoUrl {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -163,7 +161,6 @@ public class SeoUrl {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -189,7 +186,6 @@ public class SeoUrl {
    * Get foreignKey
    * @return foreignKey
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FOREIGN_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -215,7 +211,6 @@ public class SeoUrl {
    * Get routeName
    * @return routeName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ROUTE_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -241,7 +236,6 @@ public class SeoUrl {
    * Get pathInfo
    * @return pathInfo
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PATH_INFO)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -267,7 +261,6 @@ public class SeoUrl {
    * Get seoPathInfo
    * @return seoPathInfo
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SEO_PATH_INFO)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -293,7 +286,6 @@ public class SeoUrl {
    * Get isCanonical
    * @return isCanonical
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_CANONICAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -319,7 +311,6 @@ public class SeoUrl {
    * Get isModified
    * @return isModified
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_MODIFIED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -345,7 +336,6 @@ public class SeoUrl {
    * Get isDeleted
    * @return isDeleted
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_DELETED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -371,7 +361,6 @@ public class SeoUrl {
    * Runtime field, cannot be used as part of the criteria.
    * @return url
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -397,7 +386,6 @@ public class SeoUrl {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -423,7 +411,6 @@ public class SeoUrl {
    * Runtime field, cannot be used as part of the criteria.
    * @return isValid
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_VALID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -443,7 +430,6 @@ public class SeoUrl {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -458,7 +444,6 @@ public class SeoUrl {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -534,4 +519,3 @@ public class SeoUrl {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SeoUrlJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SeoUrlJsonApi.java
@@ -136,7 +136,6 @@ public class SeoUrlJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -162,7 +161,6 @@ public class SeoUrlJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -196,7 +194,6 @@ public class SeoUrlJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -222,7 +219,6 @@ public class SeoUrlJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonIgnore
 
   public Relationships getRelationships() {
@@ -264,7 +260,6 @@ public class SeoUrlJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -298,7 +293,6 @@ public class SeoUrlJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -324,7 +318,6 @@ public class SeoUrlJsonApi {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -350,7 +343,6 @@ public class SeoUrlJsonApi {
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -376,7 +368,6 @@ public class SeoUrlJsonApi {
    * Get foreignKey
    * @return foreignKey
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_FOREIGN_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -402,7 +393,6 @@ public class SeoUrlJsonApi {
    * Get routeName
    * @return routeName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ROUTE_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -428,7 +418,6 @@ public class SeoUrlJsonApi {
    * Get pathInfo
    * @return pathInfo
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PATH_INFO)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -454,7 +443,6 @@ public class SeoUrlJsonApi {
    * Get seoPathInfo
    * @return seoPathInfo
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SEO_PATH_INFO)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -480,7 +468,6 @@ public class SeoUrlJsonApi {
    * Get isCanonical
    * @return isCanonical
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_CANONICAL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -506,7 +493,6 @@ public class SeoUrlJsonApi {
    * Get isModified
    * @return isModified
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_MODIFIED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -532,7 +518,6 @@ public class SeoUrlJsonApi {
    * Get isDeleted
    * @return isDeleted
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_DELETED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -558,7 +543,6 @@ public class SeoUrlJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return url
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -584,7 +568,6 @@ public class SeoUrlJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -610,7 +593,6 @@ public class SeoUrlJsonApi {
    * Runtime field, cannot be used as part of the criteria.
    * @return isValid
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_VALID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -630,7 +612,6 @@ public class SeoUrlJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -645,7 +626,6 @@ public class SeoUrlJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -742,4 +722,3 @@ public class SeoUrlJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SeoUrlTemplate.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SeoUrlTemplate.java
@@ -75,7 +75,6 @@ public class SeoUrlTemplate {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class SeoUrlTemplate {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -127,7 +125,6 @@ public class SeoUrlTemplate {
    * Get isValid
    * @return isValid
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_IS_VALID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +150,6 @@ public class SeoUrlTemplate {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +169,6 @@ public class SeoUrlTemplate {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -188,7 +183,6 @@ public class SeoUrlTemplate {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -246,4 +240,3 @@ public class SeoUrlTemplate {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethod.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethod.java
@@ -134,7 +134,6 @@ public class ShippingMethod {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -160,7 +159,6 @@ public class ShippingMethod {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -186,7 +184,6 @@ public class ShippingMethod {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -212,7 +209,6 @@ public class ShippingMethod {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -238,7 +234,6 @@ public class ShippingMethod {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -264,7 +259,6 @@ public class ShippingMethod {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -290,7 +284,6 @@ public class ShippingMethod {
    * Get deliveryTimeId
    * @return deliveryTimeId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -316,7 +309,6 @@ public class ShippingMethod {
    * Get taxType
    * @return taxType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAX_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -342,7 +334,6 @@ public class ShippingMethod {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -368,7 +359,6 @@ public class ShippingMethod {
    * Get trackingUrl
    * @return trackingUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRACKING_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -394,7 +384,6 @@ public class ShippingMethod {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -414,7 +403,6 @@ public class ShippingMethod {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -429,7 +417,6 @@ public class ShippingMethod {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -450,7 +437,6 @@ public class ShippingMethod {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -476,7 +462,6 @@ public class ShippingMethod {
    * Get deliveryTime
    * @return deliveryTime
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -502,7 +487,6 @@ public class ShippingMethod {
    * Get availabilityRule
    * @return availabilityRule
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABILITY_RULE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -536,7 +520,6 @@ public class ShippingMethod {
    * Get prices
    * @return prices
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -562,7 +545,6 @@ public class ShippingMethod {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -596,7 +578,6 @@ public class ShippingMethod {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -622,7 +603,6 @@ public class ShippingMethod {
    * Get tax
    * @return tax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -713,4 +693,3 @@ public class ShippingMethod {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApi.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApi.java
@@ -129,7 +129,6 @@ public class ShippingMethodJsonApi {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -155,7 +154,6 @@ public class ShippingMethodJsonApi {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -189,7 +187,6 @@ public class ShippingMethodJsonApi {
    * Members of the attributes object (\&quot;attributes\&quot;) represent information about the resource object in which it&#39;s defined.
    * @return attributes
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ATTRIBUTES)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -215,7 +212,6 @@ public class ShippingMethodJsonApi {
    * Get relationships
    * @return relationships
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATIONSHIPS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -249,7 +245,6 @@ public class ShippingMethodJsonApi {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -283,7 +278,6 @@ public class ShippingMethodJsonApi {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -309,7 +303,6 @@ public class ShippingMethodJsonApi {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -335,7 +328,6 @@ public class ShippingMethodJsonApi {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -361,7 +353,6 @@ public class ShippingMethodJsonApi {
    * Get position
    * @return position
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -387,7 +378,6 @@ public class ShippingMethodJsonApi {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -413,7 +403,6 @@ public class ShippingMethodJsonApi {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -439,7 +428,6 @@ public class ShippingMethodJsonApi {
    * Get deliveryTimeId
    * @return deliveryTimeId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -465,7 +453,6 @@ public class ShippingMethodJsonApi {
    * Get taxType
    * @return taxType
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAX_TYPE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -491,7 +478,6 @@ public class ShippingMethodJsonApi {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -517,7 +503,6 @@ public class ShippingMethodJsonApi {
    * Get trackingUrl
    * @return trackingUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRACKING_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -543,7 +528,6 @@ public class ShippingMethodJsonApi {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -563,7 +547,6 @@ public class ShippingMethodJsonApi {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -578,7 +561,6 @@ public class ShippingMethodJsonApi {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -599,7 +581,6 @@ public class ShippingMethodJsonApi {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -688,4 +669,3 @@ public class ShippingMethodJsonApi {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationships.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationships.java
@@ -65,7 +65,6 @@ public class ShippingMethodJsonApiAllOfRelationships {
    * Get deliveryTime
    * @return deliveryTime
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -91,7 +90,6 @@ public class ShippingMethodJsonApiAllOfRelationships {
    * Get availabilityRule
    * @return availabilityRule
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABILITY_RULE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +115,6 @@ public class ShippingMethodJsonApiAllOfRelationships {
    * Get prices
    * @return prices
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -143,7 +140,6 @@ public class ShippingMethodJsonApiAllOfRelationships {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -169,7 +165,6 @@ public class ShippingMethodJsonApiAllOfRelationships {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -195,7 +190,6 @@ public class ShippingMethodJsonApiAllOfRelationships {
    * Get tax
    * @return tax
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -258,4 +252,3 @@ public class ShippingMethodJsonApiAllOfRelationships {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsAvailabilityRule.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsAvailabilityRule.java
@@ -49,7 +49,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRule {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRule {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRule {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleData.java
@@ -49,7 +49,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleLinks.java
@@ -45,7 +45,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsAvailabilityRuleLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsDeliveryTime.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsDeliveryTime.java
@@ -49,7 +49,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsDeliveryTime {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsDeliveryTime {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsDeliveryTime {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsDeliveryTimeLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsDeliveryTimeLinks.java
@@ -45,7 +45,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsDeliveryTimeLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsDeliveryTimeLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsMedia.java
@@ -49,7 +49,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsMedia {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsMedia {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsMediaLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsMediaLinks.java
@@ -45,7 +45,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsMediaLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsMediaLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsPrices.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsPrices.java
@@ -51,7 +51,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsPrices {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsPrices {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsPrices {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsPricesData.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsPricesData.java
@@ -49,7 +49,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsPricesData {
    * Get type
    * @return type
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsPricesData {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsPricesData {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsPricesLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsPricesLinks.java
@@ -45,7 +45,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsPricesLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsPricesLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTags.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTags.java
@@ -51,7 +51,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsTags {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -85,7 +84,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsTags {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -140,4 +138,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsTags {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTagsLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTagsLinks.java
@@ -45,7 +45,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsTagsLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsTagsLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTax.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTax.java
@@ -49,7 +49,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsTax {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsTax {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsTax {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTaxLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodJsonApiAllOfRelationshipsTaxLinks.java
@@ -45,7 +45,6 @@ public class ShippingMethodJsonApiAllOfRelationshipsTaxLinks {
    * Get related
    * @return related
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RELATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodJsonApiAllOfRelationshipsTaxLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInner.java
@@ -103,7 +103,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -129,7 +128,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -155,7 +153,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -181,7 +178,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get deliveryTimeId
    * @return deliveryTimeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -207,7 +203,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get deliveryTime
    * @return deliveryTime
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DELIVERY_TIME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -241,7 +236,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get translations
    * @return translations
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -275,7 +269,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get orderDeliveries
    * @return orderDeliveries
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_DELIVERIES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -309,7 +302,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get salesChannelDefaultAssignments
    * @return salesChannelDefaultAssignments
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_DEFAULT_ASSIGNMENTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -343,7 +335,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get salesChannels
    * @return salesChannels
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -369,7 +360,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get availabilityRule
    * @return availabilityRule
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABILITY_RULE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -395,7 +385,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get availabilityRuleId
    * @return availabilityRuleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_AVAILABILITY_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -429,7 +418,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get prices
    * @return prices
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -455,7 +443,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get mediaId
    * @return mediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -481,7 +468,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -515,7 +501,6 @@ public class ShippingMethodPageRouteResponseInner {
    * Get tags
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -596,4 +581,3 @@ public class ShippingMethodPageRouteResponseInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerAvailabilityRule.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerAvailabilityRule.java
@@ -57,7 +57,6 @@ public class ShippingMethodPageRouteResponseInnerAvailabilityRule {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ShippingMethodPageRouteResponseInnerAvailabilityRule {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +107,6 @@ public class ShippingMethodPageRouteResponseInnerAvailabilityRule {
    * Get priority
    * @return priority
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRIORITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +132,6 @@ public class ShippingMethodPageRouteResponseInnerAvailabilityRule {
    * Get invalid
    * @return invalid
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_INVALID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,4 +190,3 @@ public class ShippingMethodPageRouteResponseInnerAvailabilityRule {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerDeliveryTime.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerDeliveryTime.java
@@ -57,7 +57,6 @@ public class ShippingMethodPageRouteResponseInnerDeliveryTime {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class ShippingMethodPageRouteResponseInnerDeliveryTime {
    * Get min
    * @return min
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +107,6 @@ public class ShippingMethodPageRouteResponseInnerDeliveryTime {
    * Get max
    * @return max
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAX)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +132,6 @@ public class ShippingMethodPageRouteResponseInnerDeliveryTime {
    * Get unit
    * @return unit
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UNIT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,4 +190,3 @@ public class ShippingMethodPageRouteResponseInnerDeliveryTime {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerMedia.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerMedia.java
@@ -98,7 +98,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get userId
    * @return userId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_USER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -124,7 +123,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get mimeType
    * @return mimeType
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MIME_TYPE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,7 +148,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get fileExtension
    * @return fileExtension
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILE_EXTENSION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -176,7 +173,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get fileSize
    * @return fileSize
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILE_SIZE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -202,7 +198,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get title
    * @return title
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TITLE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -228,7 +223,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get metaDataRaw
    * @return metaDataRaw
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META_DATA_RAW)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -254,7 +248,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get mediaTypeRaw
    * @return mediaTypeRaw
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_TYPE_RAW)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -280,7 +273,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get uploadedAt
    * @return uploadedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPLOADED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -306,7 +298,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get alt
    * @return alt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ALT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -332,7 +323,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get url
    * @return url
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -358,7 +348,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get fileName
    * @return fileName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILE_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -384,7 +373,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get mediaFolderId
    * @return mediaFolderId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA_FOLDER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -410,7 +398,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get _private
    * @return _private
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRIVATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -436,7 +423,6 @@ public class ShippingMethodPageRouteResponseInnerMedia {
    * Get thumbnailsRo
    * @return thumbnailsRo
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_THUMBNAILS_RO)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -515,4 +501,3 @@ public class ShippingMethodPageRouteResponseInnerMedia {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerOrderDeliveriesInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerOrderDeliveriesInner.java
@@ -66,7 +66,6 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
    * Get orderId
    * @return orderId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ORDER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -92,7 +91,6 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
    * Get shippingOrderAddressId
    * @return shippingOrderAddressId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_ORDER_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -118,7 +116,6 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -144,7 +141,6 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
    * Get shippingDateEarliest
    * @return shippingDateEarliest
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_DATE_EARLIEST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -170,7 +166,6 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
    * Get shippingDateLatest
    * @return shippingDateLatest
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_DATE_LATEST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -196,7 +191,6 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
    * Get stateId
    * @return stateId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -259,4 +253,3 @@ public class ShippingMethodPageRouteResponseInnerOrderDeliveriesInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerPricesInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerPricesInner.java
@@ -73,7 +73,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -99,7 +98,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +123,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get ruleId
    * @return ruleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +148,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get calculation
    * @return calculation
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get quantityStart
    * @return quantityStart
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY_START)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get quantityEnd
    * @return quantityEnd
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY_END)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +223,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get price
    * @return price
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +248,6 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
    * Get calculationRuleId
    * @return calculationRuleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATION_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,4 +314,3 @@ public class ShippingMethodPageRouteResponseInnerPricesInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsInner.java
@@ -121,7 +121,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get typeId
    * @return typeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TYPE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +146,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get languageId
    * @return languageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +171,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get currencyId
    * @return currencyId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +196,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get paymentMethodId
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +221,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +246,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get countryId
    * @return countryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -277,7 +271,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get navigationCategoryId
    * @return navigationCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +296,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get navigationCategoryDepth
    * @return navigationCategoryDepth
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAVIGATION_CATEGORY_DEPTH)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -329,7 +321,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get footerCategoryId
    * @return footerCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FOOTER_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -355,7 +346,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get serviceCategoryId
    * @return serviceCategoryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SERVICE_CATEGORY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -381,7 +371,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -407,7 +396,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get shortName
    * @return shortName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHORT_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -433,7 +421,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get accessKey
    * @return accessKey
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACCESS_KEY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -459,7 +446,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -485,7 +471,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get maintenance
    * @return maintenance
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAINTENANCE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -511,7 +496,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get maintenanceIpWhitelist
    * @return maintenanceIpWhitelist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAINTENANCE_IP_WHITELIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -537,7 +521,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get mailHeaderFooterId
    * @return mailHeaderFooterId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MAIL_HEADER_FOOTER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -563,7 +546,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get customerGroupId
    * @return customerGroupId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_GROUP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -589,7 +571,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get hreflangActive
    * @return hreflangActive
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -615,7 +596,6 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
    * Get hreflangDefaultDomainId
    * @return hreflangDefaultDomainId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HREFLANG_DEFAULT_DOMAIN_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -706,4 +686,3 @@ public class ShippingMethodPageRouteResponseInnerSalesChannelDefaultAssignmentsI
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerTagsInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerTagsInner.java
@@ -45,7 +45,6 @@ public class ShippingMethodPageRouteResponseInnerTagsInner {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class ShippingMethodPageRouteResponseInnerTagsInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerTranslationsInner.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPageRouteResponseInnerTranslationsInner.java
@@ -53,7 +53,6 @@ public class ShippingMethodPageRouteResponseInnerTranslationsInner {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -79,7 +78,6 @@ public class ShippingMethodPageRouteResponseInnerTranslationsInner {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +103,6 @@ public class ShippingMethodPageRouteResponseInnerTranslationsInner {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -162,4 +159,3 @@ public class ShippingMethodPageRouteResponseInnerTranslationsInner {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPrice.java
+++ b/src/main/java/de/codebarista/shopware/model/core/ShippingMethodPrice.java
@@ -95,7 +95,6 @@ public class ShippingMethodPrice {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -121,7 +120,6 @@ public class ShippingMethodPrice {
    * Get shippingMethodId
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -147,7 +145,6 @@ public class ShippingMethodPrice {
    * Get ruleId
    * @return ruleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +170,6 @@ public class ShippingMethodPrice {
    * Get calculation
    * @return calculation
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -199,7 +195,6 @@ public class ShippingMethodPrice {
    * Get calculationRuleId
    * @return calculationRuleId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CALCULATION_RULE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -225,7 +220,6 @@ public class ShippingMethodPrice {
    * Get quantityStart
    * @return quantityStart
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY_START)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +245,6 @@ public class ShippingMethodPrice {
    * Get quantityEnd
    * @return quantityEnd
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_QUANTITY_END)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -277,7 +270,6 @@ public class ShippingMethodPrice {
    * Get currencyPrice
    * @return currencyPrice
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_PRICE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +295,6 @@ public class ShippingMethodPrice {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -323,7 +314,6 @@ public class ShippingMethodPrice {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -338,7 +328,6 @@ public class ShippingMethodPrice {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -406,4 +395,3 @@ public class ShippingMethodPrice {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Sitemap.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Sitemap.java
@@ -52,7 +52,6 @@ public class Sitemap {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -78,7 +77,6 @@ public class Sitemap {
    * Get filename
    * @return filename
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FILENAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -104,7 +102,6 @@ public class Sitemap {
    * Get created
    * @return created
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CREATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -161,4 +158,3 @@ public class Sitemap {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Snippet.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Snippet.java
@@ -80,7 +80,6 @@ public class Snippet {
      *
      * @return id
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_ID)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -101,7 +100,6 @@ public class Snippet {
      *
      * @return setId
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_SET_ID)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -128,7 +126,6 @@ public class Snippet {
      *
      * @return translationKey
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_TRANSLATION_KEY)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -155,7 +152,6 @@ public class Snippet {
      *
      * @return value
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_VALUE)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -182,7 +178,6 @@ public class Snippet {
      *
      * @return customFields
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class Snippet {
      *
      * @return createdAt
      **/
-    @jakarta.annotation.Nonnull
     @JsonProperty(JSON_PROPERTY_CREATED_AT)
     @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -217,7 +211,6 @@ public class Snippet {
      *
      * @return updatedAt
      **/
-    @jakarta.annotation.Nullable
     @JsonProperty(JSON_PROPERTY_UPDATED_AT)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -276,4 +269,3 @@ public class Snippet {
     }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SnippetSet.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SnippetSet.java
@@ -81,7 +81,6 @@ public class SnippetSet {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -107,7 +106,6 @@ public class SnippetSet {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -133,7 +131,6 @@ public class SnippetSet {
    * Get iso
    * @return iso
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ISO)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -159,7 +156,6 @@ public class SnippetSet {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -179,7 +175,6 @@ public class SnippetSet {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -194,7 +189,6 @@ public class SnippetSet {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -223,7 +217,6 @@ public class SnippetSet {
    * Get snippets
    * @return snippets
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SNIPPETS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -288,4 +281,3 @@ public class SnippetSet {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/StateMachine.java
+++ b/src/main/java/de/codebarista/shopware/model/core/StateMachine.java
@@ -77,7 +77,6 @@ public class StateMachine {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -97,7 +96,6 @@ public class StateMachine {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -112,7 +110,6 @@ public class StateMachine {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -133,7 +130,6 @@ public class StateMachine {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -167,7 +163,6 @@ public class StateMachine {
    * Get states
    * @return states
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STATES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -201,7 +196,6 @@ public class StateMachine {
    * Get transitions
    * @return transitions
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSITIONS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -264,4 +258,3 @@ public class StateMachine {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/StateMachineHistory.java
+++ b/src/main/java/de/codebarista/shopware/model/core/StateMachineHistory.java
@@ -71,7 +71,6 @@ public class StateMachineHistory {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -91,7 +90,6 @@ public class StateMachineHistory {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -106,7 +104,6 @@ public class StateMachineHistory {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -127,7 +124,6 @@ public class StateMachineHistory {
    * Get fromStateMachineState
    * @return fromStateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FROM_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -153,7 +149,6 @@ public class StateMachineHistory {
    * Get toStateMachineState
    * @return toStateMachineState
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TO_STATE_MACHINE_STATE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -214,4 +209,3 @@ public class StateMachineHistory {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/StateMachineState.java
+++ b/src/main/java/de/codebarista/shopware/model/core/StateMachineState.java
@@ -79,7 +79,6 @@ public class StateMachineState {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class StateMachineState {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class StateMachineState {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +154,6 @@ public class StateMachineState {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class StateMachineState {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,7 +187,6 @@ public class StateMachineState {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +207,6 @@ public class StateMachineState {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class StateMachineState {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/StateMachineTransition.java
+++ b/src/main/java/de/codebarista/shopware/model/core/StateMachineTransition.java
@@ -63,7 +63,6 @@ public class StateMachineTransition {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class StateMachineTransition {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class StateMachineTransition {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class StateMachineTransition {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Struct.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Struct.java
@@ -43,7 +43,6 @@ public class Struct {
    * Alias which can be used to restrict response fields. For more information see [includes](https://shopware.stoplight.io/docs/store-api/docs/concepts/search-queries.md#includes-apialias).
    * @return apiAlias
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_API_ALIAS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -96,4 +95,3 @@ public class Struct {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SubscribeToNewsletterRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SubscribeToNewsletterRequest.java
@@ -89,7 +89,6 @@ public class SubscribeToNewsletterRequest {
    * Email address that will receive the confirmation and the newsletter.
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -115,7 +114,6 @@ public class SubscribeToNewsletterRequest {
    * Defines what should be done.
    * @return option
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_OPTION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -141,7 +139,6 @@ public class SubscribeToNewsletterRequest {
    * Url of the storefront of the shop. This will be used for generating the link to the /newsletter/confirm inside the confirm email.
    * @return storefrontUrl
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_STOREFRONT_URL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -167,7 +164,6 @@ public class SubscribeToNewsletterRequest {
    * Identifier of the salutation.
    * @return salutationId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALUTATION_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -193,7 +189,6 @@ public class SubscribeToNewsletterRequest {
    * First name
    * @return firstName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -219,7 +214,6 @@ public class SubscribeToNewsletterRequest {
    * Last name
    * @return lastName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -245,7 +239,6 @@ public class SubscribeToNewsletterRequest {
    * Street
    * @return street
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_STREET)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -271,7 +264,6 @@ public class SubscribeToNewsletterRequest {
    * City
    * @return city
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CITY)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -297,7 +289,6 @@ public class SubscribeToNewsletterRequest {
    * Zip code
    * @return zipCode
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ZIP_CODE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -323,7 +314,6 @@ public class SubscribeToNewsletterRequest {
    * Zip code
    * @return tags
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TAGS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -349,7 +339,6 @@ public class SubscribeToNewsletterRequest {
    * Identifier of the language.
    * @return languageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -375,7 +364,6 @@ public class SubscribeToNewsletterRequest {
    * Custom field data that should be added to the subscription.
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -450,4 +438,3 @@ public class SubscribeToNewsletterRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Success.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Success.java
@@ -70,7 +70,6 @@ public class Success {
    * Non-standard meta-information that can not be represented as an attribute or relationship.
    * @return meta
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_META)
   @JsonInclude(content = JsonInclude.Include.ALWAYS, value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -96,7 +95,6 @@ public class Success {
    * Get links
    * @return links
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LINKS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -122,7 +120,6 @@ public class Success {
    * Get data
    * @return data
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_DATA)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -156,7 +153,6 @@ public class Success {
    * To reduce the number of HTTP requests, servers **MAY** allow responses that include related resources along with the requested primary resources. Such responses are called \&quot;compound documents\&quot;.
    * @return included
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_INCLUDED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -216,4 +212,3 @@ public class Success {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SuccessLinks.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SuccessLinks.java
@@ -57,7 +57,6 @@ public class SuccessLinks {
    * The first page of data
    * @return first
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_FIRST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class SuccessLinks {
    * The last page of data
    * @return last
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LAST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -109,7 +107,6 @@ public class SuccessLinks {
    * The previous page of data
    * @return prev
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREV)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -135,7 +132,6 @@ public class SuccessLinks {
    * The next page of data
    * @return next
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_NEXT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -194,4 +190,3 @@ public class SuccessLinks {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SuccessResponse.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SuccessResponse.java
@@ -43,7 +43,6 @@ public class SuccessResponse {
    * Get success
    * @return success
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SUCCESS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -96,4 +95,3 @@ public class SuccessResponse {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SwagLanguagePackLanguage.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SwagLanguagePackLanguage.java
@@ -63,7 +63,6 @@ public class SwagLanguagePackLanguage {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class SwagLanguagePackLanguage {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class SwagLanguagePackLanguage {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class SwagLanguagePackLanguage {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SystemConfig.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SystemConfig.java
@@ -79,7 +79,6 @@ public class SystemConfig {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class SystemConfig {
    * Get configurationKey
    * @return configurationKey
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CONFIGURATION_KEY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class SystemConfig {
    * Get configurationValue
    * @return configurationValue
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CONFIGURATION_VALUE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +154,6 @@ public class SystemConfig {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class SystemConfig {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,7 +187,6 @@ public class SystemConfig {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +207,6 @@ public class SystemConfig {
    * Get salesChannel
    * @return salesChannel
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class SystemConfig {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/SystemConfigConfigurationValue.java
+++ b/src/main/java/de/codebarista/shopware/model/core/SystemConfigConfigurationValue.java
@@ -45,7 +45,6 @@ public class SystemConfigConfigurationValue {
    * Get value
    * @return value
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_VALUE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -98,4 +97,3 @@ public class SystemConfigConfigurationValue {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Tag.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Tag.java
@@ -67,7 +67,6 @@ public class Tag {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -93,7 +92,6 @@ public class Tag {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -113,7 +111,6 @@ public class Tag {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -128,7 +125,6 @@ public class Tag {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class Tag {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Tax.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Tax.java
@@ -79,7 +79,6 @@ public class Tax {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class Tax {
    * Get taxRate
    * @return taxRate
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_TAX_RATE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class Tax {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +154,6 @@ public class Tax {
    * Added since version: 6.4.0.0.
    * @return position
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_POSITION)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -183,7 +179,6 @@ public class Tax {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class Tax {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -218,7 +212,6 @@ public class Tax {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class Tax {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/TaxProvider.java
+++ b/src/main/java/de/codebarista/shopware/model/core/TaxProvider.java
@@ -91,7 +91,6 @@ public class TaxProvider {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -117,7 +116,6 @@ public class TaxProvider {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -143,7 +141,6 @@ public class TaxProvider {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -169,7 +166,6 @@ public class TaxProvider {
    * Get priority
    * @return priority
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_PRIORITY)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -195,7 +191,6 @@ public class TaxProvider {
    * Get processUrl
    * @return processUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PROCESS_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -221,7 +216,6 @@ public class TaxProvider {
    * Get appId
    * @return appId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_APP_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -247,7 +241,6 @@ public class TaxProvider {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -267,7 +260,6 @@ public class TaxProvider {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -282,7 +274,6 @@ public class TaxProvider {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +294,6 @@ public class TaxProvider {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -374,4 +364,3 @@ public class TaxProvider {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/TaxRule.java
+++ b/src/main/java/de/codebarista/shopware/model/core/TaxRule.java
@@ -63,7 +63,6 @@ public class TaxRule {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class TaxRule {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class TaxRule {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class TaxRule {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/TaxRuleType.java
+++ b/src/main/java/de/codebarista/shopware/model/core/TaxRuleType.java
@@ -67,7 +67,6 @@ public class TaxRuleType {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -87,7 +86,6 @@ public class TaxRuleType {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -102,7 +100,6 @@ public class TaxRuleType {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -123,7 +120,6 @@ public class TaxRuleType {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -182,4 +178,3 @@ public class TaxRuleType {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Theme.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Theme.java
@@ -121,7 +121,6 @@ public class Theme {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -147,7 +146,6 @@ public class Theme {
    * Get technicalName
    * @return technicalName
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TECHNICAL_NAME)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -173,7 +171,6 @@ public class Theme {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -199,7 +196,6 @@ public class Theme {
    * Get author
    * @return author
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_AUTHOR)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -225,7 +221,6 @@ public class Theme {
    * Get description
    * @return description
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DESCRIPTION)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -251,7 +246,6 @@ public class Theme {
    * Get labels
    * @return labels
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LABELS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -277,7 +271,6 @@ public class Theme {
    * Get helpTexts
    * @return helpTexts
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_HELP_TEXTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -303,7 +296,6 @@ public class Theme {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -329,7 +321,6 @@ public class Theme {
    * Get previewMediaId
    * @return previewMediaId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PREVIEW_MEDIA_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -355,7 +346,6 @@ public class Theme {
    * Get parentThemeId
    * @return parentThemeId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PARENT_THEME_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -381,7 +371,6 @@ public class Theme {
    * Get baseConfig
    * @return baseConfig
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BASE_CONFIG)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -407,7 +396,6 @@ public class Theme {
    * Get configValues
    * @return configValues
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONFIG_VALUES)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -433,7 +421,6 @@ public class Theme {
    * Get active
    * @return active
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_ACTIVE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -453,7 +440,6 @@ public class Theme {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -468,7 +454,6 @@ public class Theme {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -489,7 +474,6 @@ public class Theme {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -523,7 +507,6 @@ public class Theme {
    * Get media
    * @return media
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_MEDIA)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -608,4 +591,3 @@ public class Theme {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Unit.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Unit.java
@@ -79,7 +79,6 @@ public class Unit {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -105,7 +104,6 @@ public class Unit {
    * Get shortCode
    * @return shortCode
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_SHORT_CODE)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -131,7 +129,6 @@ public class Unit {
    * Get name
    * @return name
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_NAME)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -157,7 +154,6 @@ public class Unit {
    * Get customFields
    * @return customFields
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOM_FIELDS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class Unit {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -192,7 +187,6 @@ public class Unit {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -213,7 +207,6 @@ public class Unit {
    * Get translated
    * @return translated
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_TRANSLATED)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -278,4 +271,3 @@ public class Unit {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/UnsubscribeToNewsletterRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/UnsubscribeToNewsletterRequest.java
@@ -45,7 +45,6 @@ public class UnsubscribeToNewsletterRequest {
    * Email address that should be removed from the mailing lists.
    * @return email
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_EMAIL)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,4 +97,3 @@ public class UnsubscribeToNewsletterRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/UpdateContext200Response.java
+++ b/src/main/java/de/codebarista/shopware/model/core/UpdateContext200Response.java
@@ -51,7 +51,6 @@ public class UpdateContext200Response {
    * @deprecated
   **/
   @Deprecated
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CONTEXT_TOKEN)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -77,7 +76,6 @@ public class UpdateContext200Response {
    * Define the URL which browser will be redirected to
    * @return redirectUrl
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_REDIRECT_URL)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -132,4 +130,3 @@ public class UpdateContext200Response {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/UpdateContextRequest.java
+++ b/src/main/java/de/codebarista/shopware/model/core/UpdateContextRequest.java
@@ -73,7 +73,6 @@ public class UpdateContextRequest {
    * Currency
    * @return currencyId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CURRENCY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -99,7 +98,6 @@ public class UpdateContextRequest {
    * Language
    * @return languageId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_LANGUAGE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -125,7 +123,6 @@ public class UpdateContextRequest {
    * Billing Address
    * @return billingAddressId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_BILLING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -151,7 +148,6 @@ public class UpdateContextRequest {
    * Shipping Address
    * @return shippingAddressId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_ADDRESS_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -177,7 +173,6 @@ public class UpdateContextRequest {
    * Payment Method
    * @return paymentMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PAYMENT_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -203,7 +198,6 @@ public class UpdateContextRequest {
    * Shipping Method
    * @return shippingMethodId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SHIPPING_METHOD_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -229,7 +223,6 @@ public class UpdateContextRequest {
    * Country
    * @return countryId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -255,7 +248,6 @@ public class UpdateContextRequest {
    * Country State
    * @return countryStateId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_COUNTRY_STATE_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -322,4 +314,3 @@ public class UpdateContextRequest {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/User.java
+++ b/src/main/java/de/codebarista/shopware/model/core/User.java
@@ -63,7 +63,6 @@ public class User {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class User {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class User {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class User {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/UserAccessKey.java
+++ b/src/main/java/de/codebarista/shopware/model/core/UserAccessKey.java
@@ -63,7 +63,6 @@ public class UserAccessKey {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class UserAccessKey {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class UserAccessKey {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class UserAccessKey {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/UserConfig.java
+++ b/src/main/java/de/codebarista/shopware/model/core/UserConfig.java
@@ -63,7 +63,6 @@ public class UserConfig {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class UserConfig {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class UserConfig {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class UserConfig {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/UserRecovery.java
+++ b/src/main/java/de/codebarista/shopware/model/core/UserRecovery.java
@@ -63,7 +63,6 @@ public class UserRecovery {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class UserRecovery {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class UserRecovery {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class UserRecovery {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/Webhook.java
+++ b/src/main/java/de/codebarista/shopware/model/core/Webhook.java
@@ -63,7 +63,6 @@ public class Webhook {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class Webhook {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class Webhook {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class Webhook {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/WebhookEventLog.java
+++ b/src/main/java/de/codebarista/shopware/model/core/WebhookEventLog.java
@@ -63,7 +63,6 @@ public class WebhookEventLog {
    * Get id
    * @return id
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class WebhookEventLog {
    * Get createdAt
    * @return createdAt
   **/
-  @jakarta.annotation.Nonnull
   @JsonProperty(JSON_PROPERTY_CREATED_AT)
   @JsonInclude(value = JsonInclude.Include.ALWAYS)
 
@@ -98,7 +96,6 @@ public class WebhookEventLog {
    * Get updatedAt
    * @return updatedAt
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_UPDATED_AT)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -150,4 +147,3 @@ public class WebhookEventLog {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/WishlistLoadRouteResponse.java
+++ b/src/main/java/de/codebarista/shopware/model/core/WishlistLoadRouteResponse.java
@@ -49,7 +49,6 @@ public class WishlistLoadRouteResponse {
    * Get wishlist
    * @return wishlist
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_WISHLIST)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -83,7 +82,6 @@ public class WishlistLoadRouteResponse {
    * Get products
    * @return products
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_PRODUCTS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -138,4 +136,3 @@ public class WishlistLoadRouteResponse {
   }
 
 }
-

--- a/src/main/java/de/codebarista/shopware/model/core/WishlistLoadRouteResponseWishlist.java
+++ b/src/main/java/de/codebarista/shopware/model/core/WishlistLoadRouteResponseWishlist.java
@@ -49,7 +49,6 @@ public class WishlistLoadRouteResponseWishlist {
    * Get customerId
    * @return customerId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_CUSTOMER_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -75,7 +74,6 @@ public class WishlistLoadRouteResponseWishlist {
    * Get salesChannelId
    * @return salesChannelId
   **/
-  @jakarta.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_SALES_CHANNEL_ID)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
 
@@ -130,4 +128,3 @@ public class WishlistLoadRouteResponseWishlist {
   }
 
 }
-


### PR DESCRIPTION
When using the search endpoint of the admin-api any property can be null due to the usage of includes or fields in the search query.